### PR TITLE
Fix fallback failing to load if the book was loaded on a different language

### DIFF
--- a/src/main/java/vazkii/patchouli/client/book/BookContents.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookContents.java
@@ -233,25 +233,22 @@ public class BookContents {
 		ResourceLocation localized = new ResourceLocation(res.getResourceDomain(),
 				res.getResourcePath().replaceAll(DEFAULT_LANG, ClientBookRegistry.INSTANCE.currentLang));
 
-		return loadJson(localized, null);
+		return loadJson(localized, res);
 	}
 
 	protected InputStream loadJson(ResourceLocation resloc, ResourceLocation fallback) {
-		IResource res = null;
 		try {
-			res = Minecraft.getMinecraft().getResourceManager().getResource(resloc);
-		} catch (FileNotFoundException e) {
-			return null;
+			return Minecraft.getMinecraft().getResourceManager().getResource(resloc).getInputStream();
 		} catch (IOException e) {
-			e.printStackTrace();
+			//no-op
 		}
 
-		if(res == null && fallback != null) {
-			new RuntimeException("Patchouli failed to load " + resloc + ". Switching to fallback.").printStackTrace();
+		if(fallback != null) {
+			System.err.println("Patchouli failed to load " + resloc + ". Switching to fallback.");
 			return loadJson(fallback, null);
 		}
 
-		return res.getInputStream();
+		return null;
 	}
 
 	private static String numberToOrdinal(int i) {


### PR DESCRIPTION
Fixes #26. 
The cause was somewhat simple - the fallback was never actually provided to the json loader, and even if it was provided, a FileNotFoundException being thrown caused an early null return.

Also changes the logging of the error from printing a stack trace to a simple stderr print, because the stack traces were quite long and in the dev enviroment it is still about 74 lines of errors even when skipping the stack trace. (A proper logging solution should be used instead but I don't really feel like replacing every stacktrace print with a logger just yet...)