### PR TITLE
Giant warning cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Thumbs.db
 /*.ipr
 /*.iws
 /*.iml
+/classes
 
 ## Private Stuffs
 /private.properties

--- a/src/main/java/vazkii/patchouli/api/IComponentProcessor.java
+++ b/src/main/java/vazkii/patchouli/api/IComponentProcessor.java
@@ -4,7 +4,6 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@SideOnly(Side.CLIENT)
 /**
  * Implement this on a class designed to process a template and the variables bound 
  * to the inside. This doesn't have to be registered anywhere, but any class implementing
@@ -13,6 +12,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
  * Instances of this class are created once for every usage of the template it's meant to 
  * process, so you can save data on a per-template basis.
  */
+@SideOnly(Side.CLIENT)
 public interface IComponentProcessor {
 
 	/**

--- a/src/main/java/vazkii/patchouli/api/ICustomComponent.java
+++ b/src/main/java/vazkii/patchouli/api/ICustomComponent.java
@@ -1,7 +1,5 @@
 package vazkii.patchouli.api;
 
-import com.google.gson.JsonPrimitive;
-
 import net.minecraft.client.gui.GuiScreen;
 
 /**
@@ -12,7 +10,7 @@ import net.minecraft.client.gui.GuiScreen;
  * the transient keyword. 
  * <br><br>
  * Non-transient String type fields you declare in instances of this may have the
- * @VariableHolder annotation associated to them, and as such, they'll load variables
+ * {@link VariableHolder} annotation associated to them, and as such, they'll load variables
  * the same way any built-in template would. Any fields with a @VariableHolder must be public.
  */
 public interface ICustomComponent {

--- a/src/main/java/vazkii/patchouli/api/IVariableProvider.java
+++ b/src/main/java/vazkii/patchouli/api/IVariableProvider.java
@@ -3,10 +3,10 @@ package vazkii.patchouli.api;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@SideOnly(Side.CLIENT)
 /**
  * A provider of variables to a template. Usually from json.
  */
+@SideOnly(Side.CLIENT)
 public interface IVariableProvider<T> {
 
 	/**

--- a/src/main/java/vazkii/patchouli/client/base/ClientProxy.java
+++ b/src/main/java/vazkii/patchouli/client/base/ClientProxy.java
@@ -8,7 +8,6 @@ import vazkii.patchouli.client.handler.BookRightClickHandler;
 import vazkii.patchouli.client.handler.MultiblockVisualizationHandler;
 import vazkii.patchouli.common.base.CommonProxy;
 import vazkii.patchouli.common.book.BookRegistry;
-import vazkii.patchouli.common.item.PatchouliItems;
 
 public class ClientProxy extends CommonProxy {
 

--- a/src/main/java/vazkii/patchouli/client/base/PersistentData.java
+++ b/src/main/java/vazkii/patchouli/client/base/PersistentData.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import net.minecraft.util.ResourceLocation;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.common.book.Book;
-import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.util.SerializationUtil;
 
 public final class PersistentData {
@@ -36,7 +35,7 @@ public final class PersistentData {
 		public int bookGuiScale = 0;
 		public boolean clickedVisualize = false;
 		
-		public Map<String, BookData> bookData = new HashMap();
+		public Map<String, BookData> bookData = new HashMap<>();
 		
 		public BookData getBookData(Book book) {
 			String res = book.resourceLoc.toString();
@@ -48,9 +47,9 @@ public final class PersistentData {
 		
 		public static final class BookData {
 			
-			public List<String> viewedEntries = new ArrayList();
-			public List<Bookmark> bookmarks = new ArrayList();
-			public List<String> history = new ArrayList();
+			public List<String> viewedEntries = new ArrayList<>();
+			public List<Bookmark> bookmarks = new ArrayList<>();
+			public List<String> history = new ArrayList<>();
 
 			public static final class Bookmark {
 				

--- a/src/main/java/vazkii/patchouli/client/book/BookCategory.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookCategory.java
@@ -5,11 +5,9 @@ import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import vazkii.patchouli.common.base.PatchouliConfig;
 import vazkii.patchouli.common.book.Book;
-import vazkii.patchouli.common.util.ItemStackUtil;
 
 public class BookCategory implements Comparable<BookCategory> {
 

--- a/src/main/java/vazkii/patchouli/client/book/BookContents.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookContents.java
@@ -1,8 +1,6 @@
 package vazkii.patchouli.client.book;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -21,14 +19,12 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.IResource;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
-import sun.plugin.viewer.context.IExplorerAppletContext;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.gui.GuiBookLanding;
 import vazkii.patchouli.client.book.template.BookTemplate;
@@ -44,14 +40,14 @@ public class BookContents {
 
 	public final Book book;
 
-	public Map<ResourceLocation, BookCategory> categories = new HashMap();
-	public Map<ResourceLocation, BookEntry> entries = new HashMap();
-	public Map<ResourceLocation, Supplier<BookTemplate>> templates = new HashMap();
-	public Map<StackWrapper, Pair<BookEntry, Integer>> recipeMappings = new HashMap();
+	public Map<ResourceLocation, BookCategory> categories = new HashMap<>();
+	public Map<ResourceLocation, BookEntry> entries = new HashMap<>();
+	public Map<ResourceLocation, Supplier<BookTemplate>> templates = new HashMap<>();
+	public Map<StackWrapper, Pair<BookEntry, Integer>> recipeMappings = new HashMap<>();
 	private boolean errored = false;
 	private Exception exception = null;
 
-	public Stack<GuiBook> guiStack = new Stack();
+	public Stack<GuiBook> guiStack = new Stack<>();
 	public GuiBook currentGui;
 	
 	public BookIcon indexIcon;
@@ -91,19 +87,19 @@ public class BookContents {
 	}
 
 	public String getSubtitle() {
-		String editionStr = "";
+		String editionStr;
 
 		try {
 			int ver = Integer.parseInt(book.version);
 			if(ver == 0)
-				return I18n.translateToLocal(book.subtitle);
+				return I18n.format(book.subtitle);
 
 			editionStr = numberToOrdinal(ver); 
 		} catch(NumberFormatException e) {
-			editionStr = I18n.translateToLocal("patchouli.gui.lexicon.dev_edition");
+			editionStr = I18n.format("patchouli.gui.lexicon.dev_edition");
 		}
 
-		return I18n.translateToLocalFormatted("patchouli.gui.lexicon.edition_str", editionStr);
+		return I18n.format("patchouli.gui.lexicon.edition_str", editionStr);
 	}
 
 	public void reload(boolean isOverride) {
@@ -121,9 +117,9 @@ public class BookContents {
 			else indexIcon = new BookIcon(book.indexIconRaw);
 		}
 
-		List<ResourceLocation> foundCategories = new ArrayList();
-		List<ResourceLocation> foundEntries = new ArrayList();
-		List<ResourceLocation> foundTemplates = new ArrayList();
+		List<ResourceLocation> foundCategories = new ArrayList<>();
+		List<ResourceLocation> foundEntries = new ArrayList<>();
+		List<ResourceLocation> foundTemplates = new ArrayList<>();
 		List<ModContainer> mods = Loader.instance().getActiveModList();
 
 		try { 
@@ -165,7 +161,7 @@ public class BookContents {
 	protected void findFiles(String dir, List<ResourceLocation> list) {
 		ModContainer mod = book.owner;
 		String id = mod.getModId();
-		CraftingHelper.findFiles(mod, String.format("assets/%s/%s/%s/%s/%s", id, BookRegistry.BOOKS_LOCATION, book.resourceLoc.getResourcePath(), DEFAULT_LANG, dir), null, pred(id, list));
+		CraftingHelper.findFiles(mod, String.format("assets/%s/%s/%s/%s/%s", id, BookRegistry.BOOKS_LOCATION, book.resourceLoc.getResourcePath(), DEFAULT_LANG, dir), null, pred(id, list), false, false);
 	}
 	
 	private BiFunction<Path, Path, Boolean> pred(String modId, List<ResourceLocation> list) {

--- a/src/main/java/vazkii/patchouli/client/book/BookIcon.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookIcon.java
@@ -2,7 +2,6 @@ package vazkii.patchouli.client.book;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
-import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/vazkii/patchouli/client/book/ClientBookRegistry.java
+++ b/src/main/java/vazkii/patchouli/client/book/ClientBookRegistry.java
@@ -37,7 +37,7 @@ import vazkii.patchouli.common.util.SerializationUtil;
 
 public class ClientBookRegistry implements IResourceManagerReloadListener {
 
-	public final Map<String, Class<? extends BookPage>> pageTypes = new HashMap();
+	public final Map<String, Class<? extends BookPage>> pageTypes = new HashMap<>();
 
 	private boolean firstLoad = true;
 

--- a/src/main/java/vazkii/patchouli/client/book/gui/GuiBook.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/GuiBook.java
@@ -18,10 +18,10 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.fml.client.config.GuiUtils;
 import vazkii.patchouli.client.base.ClientTicker;
 import vazkii.patchouli.client.base.PersistentData;
@@ -190,7 +190,7 @@ public abstract class GuiBook extends GuiScreen {
 
 			Pair<BookEntry, Integer> provider = book.contents.getEntryForStack(tooltipStack);
 			if(provider != null && (!(this instanceof GuiBookEntry) || ((GuiBookEntry) this).entry != provider.getLeft())) {
-				tooltip.add(TextFormatting.GOLD + "(" + I18n.translateToLocal("patchouli.gui.lexicon.shift_for_recipe") + ')');
+				tooltip.add(TextFormatting.GOLD + "(" + I18n.format("patchouli.gui.lexicon.shift_for_recipe") + ')');
 				targetPage = provider;
 			}
 
@@ -368,21 +368,21 @@ public abstract class GuiBook extends GuiScreen {
 		drawGradient(barLeft + 1, barTop + 1, barLeft + barWidth - 1, barTop + barHeight - 1, book.progressBarBackground);
 		drawGradient(barLeft + 1, barTop + 1, barLeft + progressWidth, barTop + barHeight - 1, book.progressBarColor);
 
-		fontRenderer.drawString(I18n.translateToLocal("patchouli.gui.lexicon.progress_meter"), barLeft, barTop - 9, book.headerColor);
+		fontRenderer.drawString(I18n.format("patchouli.gui.lexicon.progress_meter"), barLeft, barTop - 9, book.headerColor);
 
 		if(isMouseInRelativeRange(mouseX, mouseY, barLeft, barTop, barWidth, barHeight)) {
-			List<String> tooltip = new ArrayList();
-			String progressStr = I18n.translateToLocalFormatted("patchouli.gui.lexicon.progress_tooltip", unlockedEntries, totalEntries);
+			List<String> tooltip = new ArrayList<>();
+			String progressStr = I18n.format("patchouli.gui.lexicon.progress_tooltip", unlockedEntries, totalEntries);
 			tooltip.add(progressStr);
 			
 			if(unlockedSecretEntries > 0) {
 				if(unlockedSecretEntries == 1)
-					tooltip.add(TextFormatting.GRAY + I18n.translateToLocal("patchouli.gui.lexicon.progress_tooltip.secret1"));
-				else tooltip.add(TextFormatting.GRAY + I18n.translateToLocalFormatted("patchouli.gui.lexicon.progress_tooltip.secret", unlockedSecretEntries)); 
+					tooltip.add(TextFormatting.GRAY + I18n.format("patchouli.gui.lexicon.progress_tooltip.secret1"));
+				else tooltip.add(TextFormatting.GRAY + I18n.format("patchouli.gui.lexicon.progress_tooltip.secret", unlockedSecretEntries)); 
 			}
 			
 			if(unlockedEntries != totalEntries)
-				tooltip.add(TextFormatting.GRAY + I18n.translateToLocal("patchouli.gui.lexicon.progress_tooltip.info"));
+				tooltip.add(TextFormatting.GRAY + I18n.format("patchouli.gui.lexicon.progress_tooltip.info"));
 			
 			setTooltip(tooltip);
 		}

--- a/src/main/java/vazkii/patchouli/client/book/gui/GuiBookCategory.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/GuiBookCategory.java
@@ -12,7 +12,6 @@ import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.button.GuiButtonCategory;
 import vazkii.patchouli.common.base.PatchouliConfig;
 import vazkii.patchouli.common.book.Book;
-import vazkii.patchouli.common.book.BookRegistry;
 
 public class GuiBookCategory extends GuiBookEntryList {
 
@@ -41,7 +40,7 @@ public class GuiBookCategory extends GuiBookEntryList {
 	@Override
 	protected void addSubcategoryButtons() {
 		int i = 0;
-		List<BookCategory> categories = new ArrayList(book.contents.categories.values());
+		List<BookCategory> categories = new ArrayList<>(book.contents.categories.values());
 		Collections.sort(categories);
 		
 		for(BookCategory ocategory : categories) {

--- a/src/main/java/vazkii/patchouli/client/book/gui/GuiBookEntryList.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/GuiBookEntryList.java
@@ -9,11 +9,10 @@ import java.util.List;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.util.text.translation.I18n;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.button.GuiButtonCategory;
 import vazkii.patchouli.client.book.gui.button.GuiButtonEntry;
-import vazkii.patchouli.common.base.PatchouliConfig;
 import vazkii.patchouli.common.book.Book;
 
 public abstract class GuiBookEntryList extends GuiBook {
@@ -51,7 +50,7 @@ public abstract class GuiBookEntryList extends GuiBook {
 		searchField.setCanLoseFocus(false);
 		searchField.setFocused(true);
 		
-		dependentButtons = new ArrayList();
+		dependentButtons = new ArrayList<>();
 		buildEntryButtons();
 	}
 	
@@ -81,7 +80,7 @@ public abstract class GuiBookEntryList extends GuiBook {
 		
 		if(page == 0) {
 			drawCenteredStringNoShadow(getName(), LEFT_PAGE_X + PAGE_WIDTH / 2, TOP_PADDING, book.headerColor);
-			drawCenteredStringNoShadow(I18n.translateToLocal("patchouli.gui.lexicon.chapters"), RIGHT_PAGE_X + PAGE_WIDTH / 2, TOP_PADDING, book.headerColor);
+			drawCenteredStringNoShadow(I18n.format("patchouli.gui.lexicon.chapters"), RIGHT_PAGE_X + PAGE_WIDTH / 2, TOP_PADDING, book.headerColor);
 
 			drawSeparator(book, LEFT_PAGE_X, TOP_PADDING + 12);
 			drawSeparator(book, RIGHT_PAGE_X, TOP_PADDING + 12);
@@ -102,9 +101,9 @@ public abstract class GuiBookEntryList extends GuiBook {
 		}
 		
 		if(visibleEntries.isEmpty()) {
-			drawCenteredStringNoShadow(I18n.translateToLocal("patchouli.gui.lexicon.no_results"), GuiBook.RIGHT_PAGE_X + GuiBook.PAGE_WIDTH / 2, 80, 0x333333);
+			drawCenteredStringNoShadow(I18n.format("patchouli.gui.lexicon.no_results"), GuiBook.RIGHT_PAGE_X + GuiBook.PAGE_WIDTH / 2, 80, 0x333333);
 			GlStateManager.scale(2F, 2F, 2F);
-			drawCenteredStringNoShadow(I18n.translateToLocal("patchouli.gui.lexicon.sad"), GuiBook.RIGHT_PAGE_X / 2 + GuiBook.PAGE_WIDTH / 4, 47, 0x999999);
+			drawCenteredStringNoShadow(I18n.format("patchouli.gui.lexicon.sad"), GuiBook.RIGHT_PAGE_X / 2 + GuiBook.PAGE_WIDTH / 4, 47, 0x999999);
 			GlStateManager.scale(0.5F, 0.5F, 0.5F);
 		}
 	}

--- a/src/main/java/vazkii/patchouli/client/book/gui/GuiBookHistory.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/GuiBookHistory.java
@@ -3,8 +3,8 @@ package vazkii.patchouli.client.book.gui;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;
 import vazkii.patchouli.client.base.PersistentData;
 import vazkii.patchouli.client.base.PersistentData.DataHolder.BookData;
 import vazkii.patchouli.client.book.BookEntry;
@@ -18,12 +18,12 @@ public class GuiBookHistory extends GuiBookEntryList {
 
 	@Override
 	protected String getName() {
-		return I18n.translateToLocal("patchouli.gui.lexicon.history");
+		return I18n.format("patchouli.gui.lexicon.history");
 	}
 
 	@Override
 	protected String getDescriptionText() {
-		return I18n.translateToLocal("patchouli.gui.lexicon.history.info");
+		return I18n.format("patchouli.gui.lexicon.history.info");
 	}
 	
 	@Override
@@ -41,7 +41,7 @@ public class GuiBookHistory extends GuiBookEntryList {
 		BookData data = PersistentData.data.getBookData(book);
 		
 		return data.history.stream()
-				.map((s) -> new ResourceLocation(s))
+				.map(ResourceLocation::new)
 				.map((res) -> book.contents.entries.get(res))
 				.filter((e) -> e != null && !e.isLocked())
 				.collect(Collectors.toList());

--- a/src/main/java/vazkii/patchouli/client/book/gui/GuiBookIndex.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/GuiBookIndex.java
@@ -2,10 +2,9 @@ package vazkii.patchouli.client.book.gui;
 
 import java.util.Collection;
 
-import net.minecraft.util.text.translation.I18n;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.common.book.Book;
-import vazkii.patchouli.client.book.BookContents;
 
 public class GuiBookIndex extends GuiBookEntryList {
 
@@ -15,12 +14,12 @@ public class GuiBookIndex extends GuiBookEntryList {
 
 	@Override
 	protected String getName() {
-		return I18n.translateToLocal("patchouli.gui.lexicon.index");
+		return I18n.format("patchouli.gui.lexicon.index");
 	}
 
 	@Override
 	protected String getDescriptionText() {
-		return I18n.translateToLocal("patchouli.gui.lexicon.index.info");
+		return I18n.format("patchouli.gui.lexicon.index.info");
 	}
 
 	@Override

--- a/src/main/java/vazkii/patchouli/client/book/gui/GuiBookLanding.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/GuiBookLanding.java
@@ -10,9 +10,9 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.client.IModGuiFactory;
 import vazkii.patchouli.client.base.PersistentData;
@@ -41,7 +41,7 @@ public class GuiBookLanding extends GuiBook {
 	public void initGui() {
 		super.initGui();
 
-		text = new BookTextRenderer(this, I18n.translateToLocal(book.landingText), LEFT_PAGE_X, TOP_PADDING + 25);
+		text = new BookTextRenderer(this, I18n.format(book.landingText), LEFT_PAGE_X, TOP_PADDING + 25);
 
 		int x = bookLeft + (PatchouliConfig.disableAdvancementLocking ? 25 : 20);
 		int y = bookTop + FULL_HEIGHT - (PatchouliConfig.disableAdvancementLocking ? 25 : 62);
@@ -70,7 +70,7 @@ public class GuiBookLanding extends GuiBook {
 			buttonList.add(new GuiButtonBookEdit(this, x + (pos++) * dist, y));
 		
 		int i = 0;
-		List<BookCategory> categories = new ArrayList(book.contents.categories.values());
+		List<BookCategory> categories = new ArrayList<>(book.contents.categories.values());
 		Collections.sort(categories);
 
 		for(BookCategory category : categories) {	
@@ -97,7 +97,7 @@ public class GuiBookLanding extends GuiBook {
 	void drawForegroundElements(int mouseX, int mouseY, float partialTicks) {
 		text.render(mouseX, mouseY);
 
-		drawCenteredStringNoShadow(I18n.translateToLocal("patchouli.gui.lexicon.categories"), RIGHT_PAGE_X + PAGE_WIDTH / 2, TOP_PADDING, book.headerColor);
+		drawCenteredStringNoShadow(I18n.format("patchouli.gui.lexicon.categories"), RIGHT_PAGE_X + PAGE_WIDTH / 2, TOP_PADDING, book.headerColor);
 
 		int topSeparator = TOP_PADDING + 12;
 		int bottomSeparator = topSeparator + 25 + 24 * ((loadedCategories - 1) / 4 + 1);
@@ -110,8 +110,8 @@ public class GuiBookLanding extends GuiBook {
 			int x = RIGHT_PAGE_X  + PAGE_WIDTH / 2; 
 			int y = bottomSeparator + 12;
 			
-			drawCenteredStringNoShadow(I18n.translateToLocal("patchouli.gui.lexicon.loading_error"), x, y, 0xFF0000);
-			drawCenteredStringNoShadow(I18n.translateToLocal("patchouli.gui.lexicon.loading_error_hover"), x, y + 10, 0x777777);
+			drawCenteredStringNoShadow(I18n.format("patchouli.gui.lexicon.loading_error"), x, y, 0xFF0000);
+			drawCenteredStringNoShadow(I18n.format("patchouli.gui.lexicon.loading_error_hover"), x, y + 10, 0x777777);
 
 			x -= PAGE_WIDTH / 2;
 			y -= 4;
@@ -138,7 +138,7 @@ public class GuiBookLanding extends GuiBook {
 	
 	void makeErrorTooltip() {
 		Throwable e = book.contents.getException();
-		List<String> lines = new LinkedList();
+		List<String> lines = new LinkedList<>();
 		while(e != null) {
 			String msg = e.getMessage();
 			if(msg != null && !msg.isEmpty())
@@ -147,7 +147,7 @@ public class GuiBookLanding extends GuiBook {
 		}
 		
 		if(!lines.isEmpty()) {
-			lines.add(TextFormatting.GREEN + I18n.translateToLocal("patchouli.gui.lexicon.loading_error_log"));
+			lines.add(TextFormatting.GREEN + I18n.format("patchouli.gui.lexicon.loading_error_log"));
 			setTooltip(lines);
 		}
 	}

--- a/src/main/java/vazkii/patchouli/client/book/gui/GuiBookWriter.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/GuiBookWriter.java
@@ -6,7 +6,7 @@ import org.lwjgl.input.Keyboard;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiTextField;
-import net.minecraft.util.text.translation.I18n;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.gui.button.GuiButtonBookResize;
 import vazkii.patchouli.common.book.Book;
 
@@ -26,7 +26,7 @@ public class GuiBookWriter extends GuiBook {
 	public void initGui() {
 		super.initGui();
 		
-		text = new BookTextRenderer(this, I18n.translateToLocal("patchouli.gui.lexicon.editor.info"), LEFT_PAGE_X, TOP_PADDING + 20);
+		text = new BookTextRenderer(this, I18n.format("patchouli.gui.lexicon.editor.info"), LEFT_PAGE_X, TOP_PADDING + 20);
 		textfield = new GuiTextField(0, fontRenderer, 10, FULL_HEIGHT - 40, PAGE_WIDTH, 20);
 		textfield.setMaxStringLength(Integer.MAX_VALUE);
 		textfield.setText(savedText);
@@ -41,11 +41,11 @@ public class GuiBookWriter extends GuiBook {
 	void drawForegroundElements(int mouseX, int mouseY, float partialTicks) {
 		super.drawForegroundElements(mouseX, mouseY, partialTicks);
 		
-		drawCenteredStringNoShadow(I18n.translateToLocal("patchouli.gui.lexicon.editor"), LEFT_PAGE_X + PAGE_WIDTH / 2, TOP_PADDING, book.headerColor);
+		drawCenteredStringNoShadow(I18n.format("patchouli.gui.lexicon.editor"), LEFT_PAGE_X + PAGE_WIDTH / 2, TOP_PADDING, book.headerColor);
 		drawSeparator(book, LEFT_PAGE_X, TOP_PADDING + 12);
 
 		if(drawHeader) {
-			drawCenteredStringNoShadow(I18n.translateToLocal("patchouli.gui.lexicon.editor.mock_header"), RIGHT_PAGE_X + PAGE_WIDTH / 2, TOP_PADDING, book.headerColor);
+			drawCenteredStringNoShadow(I18n.format("patchouli.gui.lexicon.editor.mock_header"), RIGHT_PAGE_X + PAGE_WIDTH / 2, TOP_PADDING, book.headerColor);
 			drawSeparator(book, RIGHT_PAGE_X, TOP_PADDING + 12);
 		}
 		

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookAdvancements.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookAdvancements.java
@@ -1,13 +1,13 @@
 package vazkii.patchouli.client.book.gui.button;
 
-import net.minecraft.util.text.translation.I18n;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
 public class GuiButtonBookAdvancements extends GuiButtonBook {
 
 	public GuiButtonBookAdvancements(GuiBook parent, int x, int y) {
 		super(parent, x, y, 330, 20, 11, 11,
-				I18n.translateToLocal("patchouli.gui.lexicon.button.advancements"));
+				I18n.format("patchouli.gui.lexicon.button.advancements"));
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookArrow.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookArrow.java
@@ -1,6 +1,6 @@
 package vazkii.patchouli.client.book.gui.button;
 
-import net.minecraft.util.text.translation.I18n;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
 public class GuiButtonBookArrow extends GuiButtonBook {
@@ -9,7 +9,7 @@ public class GuiButtonBookArrow extends GuiButtonBook {
 	
 	public GuiButtonBookArrow(GuiBook parent, int x, int y, boolean left) {
 		super(parent, x, y, 272, left ? 10 : 0, 18, 10, () -> parent.canSeePageButton(left),
-				I18n.translateToLocal(left ? "patchouli.gui.lexicon.button.prev_page" : "patchouli.gui.lexicon.button.next_page"));
+				I18n.format(left ? "patchouli.gui.lexicon.button.prev_page" : "patchouli.gui.lexicon.button.next_page"));
 		this.left = left;
 	}
 

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookArrowSmall.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookArrowSmall.java
@@ -2,7 +2,7 @@ package vazkii.patchouli.client.book.gui.button;
 
 import com.google.common.base.Supplier;
 
-import net.minecraft.util.text.translation.I18n;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
 public class GuiButtonBookArrowSmall extends GuiButtonBook {
@@ -11,7 +11,7 @@ public class GuiButtonBookArrowSmall extends GuiButtonBook {
 	
 	public GuiButtonBookArrowSmall(GuiBook parent, int x, int y, boolean left, Supplier<Boolean> displayCondition) {
 		super(parent, x, y, 272, left ? 27 : 20, 5, 7, displayCondition,
-				I18n.translateToLocal(left ? "patchouli.gui.lexicon.button.prev_page" : "patchouli.gui.lexicon.button.next_page"));
+				I18n.format(left ? "patchouli.gui.lexicon.button.prev_page" : "patchouli.gui.lexicon.button.next_page"));
 		this.left = left;
 	}
 

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookBack.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookBack.java
@@ -1,15 +1,15 @@
 package vazkii.patchouli.client.book.gui.button;
 
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
 public class GuiButtonBookBack extends GuiButtonBook {
 
 	public GuiButtonBookBack(GuiBook parent, int x, int y) {
-		super(parent, x, y, 308, 0, 18, 9, () -> parent.canSeeBackButton(),
-				I18n.translateToLocal("patchouli.gui.lexicon.button.back"),
-				TextFormatting.GRAY + I18n.translateToLocal("patchouli.gui.lexicon.button.back.info"));
+		super(parent, x, y, 308, 0, 18, 9, parent::canSeeBackButton,
+				I18n.format("patchouli.gui.lexicon.button.back"),
+				TextFormatting.GRAY + I18n.format("patchouli.gui.lexicon.button.back.info"));
 	}
 	
 	

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookBookmark.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookBookmark.java
@@ -3,8 +3,8 @@ package vazkii.patchouli.client.book.gui.button;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import vazkii.patchouli.client.base.PersistentData.DataHolder.BookData.Bookmark;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
@@ -44,7 +44,7 @@ public class GuiButtonBookBookmark extends GuiButtonBook {
 			GlStateManager.disableDepth();
 			String s = Integer.toString(bookmark.page + 1);
 			if(multiblock)
-				s = I18n.translateToLocal("patchouli.gui.lexicon.visualize_letter");
+				s = I18n.format("patchouli.gui.lexicon.visualize_letter");
 			mc.fontRenderer.drawStringWithShadow(s, px + 12, py + 10, 0xFFFFFF);
 			GlStateManager.popMatrix();
 		}
@@ -54,11 +54,11 @@ public class GuiButtonBookBookmark extends GuiButtonBook {
 		BookEntry entry = bookmark == null ? null : bookmark.getEntry(book);
 
 		if(bookmark == null || entry == null)
-			return new String[] { I18n.translateToLocal("patchouli.gui.lexicon.add_bookmark") };
+			return new String[] { I18n.format("patchouli.gui.lexicon.add_bookmark") };
 
 		return new String[] {
 				entry.getName(),
-				TextFormatting.GRAY + I18n.translateToLocal(multiblock 
+				TextFormatting.GRAY + I18n.format(multiblock 
 						? "patchouli.gui.lexicon.multiblock_bookmark"
 								: "patchouli.gui.lexicon.remove_bookmark")
 		};

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookConfig.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookConfig.java
@@ -1,13 +1,13 @@
 package vazkii.patchouli.client.book.gui.button;
 
-import net.minecraft.util.text.translation.I18n;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
 public class GuiButtonBookConfig extends GuiButtonBook {
 
 	public GuiButtonBookConfig(GuiBook parent, int x, int y) {
 		super(parent, x, y, 308, 20, 11, 11,
-				I18n.translateToLocal("patchouli.gui.lexicon.button.config"));
+				I18n.format("patchouli.gui.lexicon.button.config"));
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookEdit.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookEdit.java
@@ -1,15 +1,15 @@
 package vazkii.patchouli.client.book.gui.button;
 
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
 public class GuiButtonBookEdit extends GuiButtonBook {
 
 	public GuiButtonBookEdit(GuiBook parent, int x, int y) {
 		super(parent, x, y, 308, 9, 11, 11,
-				I18n.translateToLocal("patchouli.gui.lexicon.button.editor"),
-				TextFormatting.GRAY + I18n.translateToLocal("patchouli.gui.lexicon.button.editor.info"));
+				I18n.format("patchouli.gui.lexicon.button.editor"),
+				TextFormatting.GRAY + I18n.format("patchouli.gui.lexicon.button.editor.info"));
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookEye.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookEye.java
@@ -1,8 +1,8 @@
 package vazkii.patchouli.client.book.gui.button;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import vazkii.patchouli.client.base.ClientTicker;
 import vazkii.patchouli.client.base.PersistentData;
 import vazkii.patchouli.client.book.gui.GuiBook;
@@ -11,8 +11,8 @@ public class GuiButtonBookEye extends GuiButtonBook {
 
 	public GuiButtonBookEye(GuiBook parent, int x, int y) {
 		super(parent, x, y, 308, 31, 11, 11,
-				I18n.translateToLocal("patchouli.gui.lexicon.button.visualize"),
-				TextFormatting.GRAY + I18n.translateToLocal("patchouli.gui.lexicon.button.visualize.info"));
+				I18n.format("patchouli.gui.lexicon.button.visualize"),
+				TextFormatting.GRAY + I18n.format("patchouli.gui.lexicon.button.visualize.info"));
 	}
 	
 	@Override

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookHistory.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookHistory.java
@@ -1,13 +1,13 @@
 package vazkii.patchouli.client.book.gui.button;
 
-import net.minecraft.util.text.translation.I18n;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
 public class GuiButtonBookHistory extends GuiButtonBook {
 
 	public GuiButtonBookHistory(GuiBook parent, int x, int y) {
 		super(parent, x, y, 330, 31, 11, 11,
-				I18n.translateToLocal("patchouli.gui.lexicon.button.history"));
+				I18n.format("patchouli.gui.lexicon.button.history"));
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookResize.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBookResize.java
@@ -1,10 +1,10 @@
 package vazkii.patchouli.client.book.gui.button;
 
+import java.util.Arrays;
 import java.util.List;
 
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
-import scala.actors.threadpool.Arrays;
 import vazkii.patchouli.client.base.PersistentData;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
@@ -14,15 +14,15 @@ public class GuiButtonBookResize extends GuiButtonBook {
 	
 	public GuiButtonBookResize(GuiBook parent, int x, int y, boolean uiscale) {
 		super(parent, x, y, 330, 9, 11, 11,
-				I18n.translateToLocal("patchouli.gui.lexicon.button.resize"));
+				I18n.format("patchouli.gui.lexicon.button.resize"));
 		this.uiscale = uiscale;
 	}
 	
 	@Override
 	public List<String> getTooltip() {
-		return !uiscale ? tooltip : Arrays.asList(new String[] { 
+		return !uiscale ? tooltip : Arrays.asList(
 				tooltip.get(0),
-				TextFormatting.GRAY + I18n.translateToLocalFormatted("patchouli.gui.lexicon.button.resize.size" + PersistentData.data.bookGuiScale)});
+				TextFormatting.GRAY + I18n.format("patchouli.gui.lexicon.button.resize.size" + PersistentData.data.bookGuiScale));
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonCategory.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonCategory.java
@@ -4,9 +4,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.SoundHandler;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import vazkii.patchouli.client.base.ClientTicker;
 import vazkii.patchouli.client.book.BookCategory;
 import vazkii.patchouli.client.book.BookIcon;
@@ -49,7 +48,7 @@ public class GuiButtonCategory extends GuiButton {
 			else timeHovered = Math.max(0, timeHovered - ClientTicker.delta);
 			
 			float time = Math.max(0, Math.min(ANIM_TIME, timeHovered + (hovered ? partialTicks : -partialTicks)));
-			float transparency = 0.5F - ((float) time / ANIM_TIME) * 0.5F;
+			float transparency = 0.5F - (time / ANIM_TIME) * 0.5F;
 			boolean locked = category != null && category.isLocked();
 
 			if(locked) {
@@ -66,11 +65,11 @@ public class GuiButtonCategory extends GuiButton {
 			GlStateManager.color(1F, 1F, 1F, 1F);
 			
 			if(unread) 
-				parent.drawWarning(parent.book, x, y, 0);
+				GuiBook.drawWarning(parent.book, x, y, 0);
 			GlStateManager.popMatrix();
 			
 			if(hovered)
-				parent.setTooltip(locked ? (TextFormatting.GRAY + I18n.translateToLocal("patchouli.gui.lexicon.locked")) : name);		
+				parent.setTooltip(locked ? (TextFormatting.GRAY + I18n.format("patchouli.gui.lexicon.locked")) : name);		
 			}
 	}
 	

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonEntry.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonEntry.java
@@ -5,9 +5,8 @@ import net.minecraft.client.audio.SoundHandler;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import vazkii.patchouli.client.base.ClientTicker;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
@@ -40,7 +39,7 @@ public class GuiButtonEntry extends GuiButton {
 			else timeHovered = Math.max(0, timeHovered - ClientTicker.delta);
 			
 			float time = Math.max(0, Math.min(ANIM_TIME, timeHovered + (hovered ? partialTicks : -partialTicks)));
-			float widthFract = (float) time / ANIM_TIME;
+			float widthFract = time / ANIM_TIME;
 			boolean locked = entry.isLocked();
 			
 			GlStateManager.scale(0.5F, 0.5F, 0.5F);
@@ -58,7 +57,7 @@ public class GuiButtonEntry extends GuiButton {
 			int color = parent.book.textColor;
 			String name = (entry.isPriority() ? TextFormatting.ITALIC : "") + entry.getName();
 			if(locked) {
-				name = I18n.translateToLocal("patchouli.gui.lexicon.locked");
+				name = I18n.format("patchouli.gui.lexicon.locked");
 				color = 0x77000000 | (parent.book.textColor & 0x00FFFFFF);
 			}
 			if(entry.isSecret())
@@ -70,7 +69,7 @@ public class GuiButtonEntry extends GuiButton {
 			mc.fontRenderer.setUnicodeFlag(unicode);
 			
 			if(unread)
-				parent.drawWarning(parent.book, x + width - 5, y, entry.hashCode());
+				GuiBook.drawWarning(parent.book, x + width - 5, y, entry.hashCode());
 		}
 	}
 	

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonIndex.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonIndex.java
@@ -1,13 +1,12 @@
 package vazkii.patchouli.client.book.gui.button;
 
-import net.minecraft.util.text.translation.I18n;
-import vazkii.patchouli.client.book.BookIcon;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
 public class GuiButtonIndex extends GuiButtonCategory {
 
 	public GuiButtonIndex(GuiBook parent, int x, int y) {
-		super(parent, x, y, parent.book.contents.indexIcon, I18n.translateToLocal("patchouli.gui.lexicon.index"));
+		super(parent, x, y, parent.book.contents.indexIcon, I18n.format("patchouli.gui.lexicon.index"));
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/client/book/page/PageCrafting.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageCrafting.java
@@ -1,13 +1,14 @@
 package vazkii.patchouli.client.book.page;
 
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.common.crafting.IShapedRecipe;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
@@ -19,15 +20,15 @@ public class PageCrafting extends PageDoubleRecipe<IRecipe> {
 	protected void drawRecipe(IRecipe recipe, int recipeX, int recipeY, int mouseX, int mouseY, boolean second) {
 		mc.renderEngine.bindTexture(book.craftingResource);
 		GlStateManager.enableBlend();
-		parent.drawModalRectWithCustomSizedTexture(recipeX - 2, recipeY - 2, 0, 0, 100, 62, 128, 128);
+		Gui.drawModalRectWithCustomSizedTexture(recipeX - 2, recipeY - 2, 0, 0, 100, 62, 128, 128);
 		
 		boolean shaped = recipe instanceof IShapedRecipe;
 		if(!shaped) {
 			int iconX = recipeX + 62;
 			int iconY = recipeY + 2;
-			parent.drawModalRectWithCustomSizedTexture(iconX, iconY, 0, 64, 11, 11, 128, 128);
+			Gui.drawModalRectWithCustomSizedTexture(iconX, iconY, 0, 64, 11, 11, 128, 128);
 			if(parent.isMouseInRelativeRange(mouseX, mouseY, iconX, iconY, 11, 11))
-				parent.setTooltip(I18n.translateToLocal("patchouli.gui.lexicon.shapeless"));
+				parent.setTooltip(I18n.format("patchouli.gui.lexicon.shapeless"));
 		}
 
 		parent.drawCenteredStringNoShadow(getTitle(second), GuiBook.PAGE_WIDTH / 2, recipeY - 10, book.headerColor);

--- a/src/main/java/vazkii/patchouli/client/book/page/PageEntity.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageEntity.java
@@ -8,12 +8,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.nbt.NBTException;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.registry.EntityEntry;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
@@ -34,7 +34,7 @@ public class PageEntity extends PageWithText {
 	String name;
 
 	transient boolean errored;
-	transient Constructor<Entity> constructor;
+	transient Constructor<? extends Entity> constructor;
 	transient Entity entity;
 	transient float renderScale, offset;
 	transient NBTTagCompound nbt;
@@ -43,7 +43,7 @@ public class PageEntity extends PageWithText {
 	public void build(BookEntry entry, int pageNum) {
 		super.build(entry, pageNum);
 		
-		String nbtStr = "";
+		String nbtStr;
 		int nbtStart = entityId.indexOf("{");
 		if(nbtStart > 0) {
 			nbtStr = entityId.substring(nbtStart).replaceAll("([^\\\\])'", "$1\"").replaceAll("\\\\'", "'");
@@ -60,7 +60,7 @@ public class PageEntity extends PageWithText {
 		if (entityEntry == null)
 			throw new RuntimeException("Could not find entity: " + entityId);
 
-		Class clazz = entityEntry.getEntityClass();
+		Class<? extends Entity> clazz = entityEntry.getEntityClass();
 		try {
 			constructor = clazz.getConstructor(World.class);
 		} catch(Exception e) {
@@ -91,7 +91,7 @@ public class PageEntity extends PageWithText {
 		parent.drawCenteredStringNoShadow(name, GuiBook.PAGE_WIDTH / 2, 0, book.headerColor);
 
 		if(errored)
-			fontRenderer.drawStringWithShadow(I18n.translateToLocal("patchouli.gui.lexicon.loading_error"), 58, 60, 0xFF0000);
+			fontRenderer.drawStringWithShadow(I18n.format("patchouli.gui.lexicon.loading_error"), 58, 60, 0xFF0000);
 		
 		if(entity != null)
 			renderEntity(parent.mc.world, ClientTicker.total);

--- a/src/main/java/vazkii/patchouli/client/book/page/PageImage.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageImage.java
@@ -1,5 +1,6 @@
 package vazkii.patchouli.client.book.page;
 
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
@@ -52,8 +53,8 @@ public class PageImage extends PageWithText {
 		if(images.length > 1 && border) {
 			int xs = x + 83;
 			int ys = y + 92;
-			parent.drawRect(xs, ys, xs + 20, ys + 11, 0x44000000);
-			parent.drawRect(xs - 1, ys - 1, xs + 20, ys + 11, 0x44000000);
+			Gui.drawRect(xs, ys, xs + 20, ys + 11, 0x44000000);
+			Gui.drawRect(xs - 1, ys - 1, xs + 20, ys + 11, 0x44000000);
 		}
 		
 		super.render(mouseX, mouseY, pticks);

--- a/src/main/java/vazkii/patchouli/client/book/page/PageRelations.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageRelations.java
@@ -3,11 +3,12 @@ package vazkii.patchouli.client.book.page;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
@@ -28,7 +29,7 @@ public class PageRelations extends PageWithText {
 		entryObjs = entries.stream()
 				.map((s) -> s.contains(":") ? new ResourceLocation(s) : new ResourceLocation(book.getModNamespace(), s))
 				.map((res) -> book.contents.entries.get(res))
-				.filter((e) -> e != null)
+				.filter(Objects::nonNull)
 				.collect(Collectors.toList());
 	}
 	
@@ -36,7 +37,7 @@ public class PageRelations extends PageWithText {
 	public void onDisplayed(GuiBookEntry parent, int left, int top) {
 		super.onDisplayed(parent, left, top);
 		
-		List<BookEntry> displayedEntries = new ArrayList(entryObjs);
+		List<BookEntry> displayedEntries = new ArrayList<>(entryObjs);
 		displayedEntries.removeIf(BookEntry::shouldHide);
 		Collections.sort(displayedEntries);
 		for(int i = 0; i < displayedEntries.size(); i++) {
@@ -53,8 +54,8 @@ public class PageRelations extends PageWithText {
 	
 	@Override
 	public void render(int mouseX, int mouseY, float pticks) {
-		parent.drawCenteredStringNoShadow(title == null || title.isEmpty() ? I18n.translateToLocal("patchouli.gui.lexicon.relations") : title, GuiBook.PAGE_WIDTH / 2, 0, book.headerColor);
-		parent.drawSeparator(book, 0, 12);
+		parent.drawCenteredStringNoShadow(title == null || title.isEmpty() ? I18n.format("patchouli.gui.lexicon.relations") : title, GuiBook.PAGE_WIDTH / 2, 0, book.headerColor);
+		GuiBook.drawSeparator(book, 0, 12);
 		
 		super.render(mouseX, mouseY, pticks);
 	}

--- a/src/main/java/vazkii/patchouli/client/book/page/PageSmelting.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageSmelting.java
@@ -1,5 +1,6 @@
 package vazkii.patchouli.client.book.page;
 
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
@@ -15,7 +16,7 @@ public class PageSmelting extends PageDoubleRecipe<Tuple<ItemStack, ItemStack>> 
     protected void drawRecipe(Tuple<ItemStack, ItemStack> recipe, int recipeX, int recipeY, int mouseX, int mouseY, boolean second) {
         mc.renderEngine.bindTexture(book.craftingResource);
         GlStateManager.enableBlend();
-        parent.drawModalRectWithCustomSizedTexture(recipeX, recipeY, 11, 71, 96, 24, 128, 128);
+        Gui.drawModalRectWithCustomSizedTexture(recipeX, recipeY, 11, 71, 96, 24, 128, 128);
         parent.drawCenteredStringNoShadow(getTitle(second), GuiBook.PAGE_WIDTH / 2, recipeY - 10, book.headerColor);
 
         renderItem(recipeX + 4, recipeY + 4, mouseX, mouseY, recipe.getFirst());

--- a/src/main/java/vazkii/patchouli/client/book/page/PageSpotlight.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageSpotlight.java
@@ -1,6 +1,8 @@
 package vazkii.patchouli.client.book.page;
 
 import com.google.gson.annotations.SerializedName;
+
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import vazkii.patchouli.client.book.BookEntry;
@@ -31,7 +33,7 @@ public class PageSpotlight extends PageWithText {
 		
 		mc.renderEngine.bindTexture(book.craftingResource);
 		GlStateManager.enableBlend();
-		parent.drawModalRectWithCustomSizedTexture(GuiBook.PAGE_WIDTH / 2 - w / 2, 10, 0, 128 - h, w, h, 128, 128);
+		Gui.drawModalRectWithCustomSizedTexture(GuiBook.PAGE_WIDTH / 2 - w / 2, 10, 0, 128 - h, w, h, 128, 128);
 		
 		parent.drawCenteredStringNoShadow(title != null && !title.isEmpty() ? title : itemStack.getDisplayName(), GuiBook.PAGE_WIDTH / 2, 0, book.headerColor);
 		renderItem(GuiBook.PAGE_WIDTH / 2 - 8, 15, mouseX, mouseY, itemStack);

--- a/src/main/java/vazkii/patchouli/client/book/page/PageTemplate.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageTemplate.java
@@ -1,8 +1,5 @@
 package vazkii.patchouli.client.book.page;
 
-import java.util.function.Supplier;
-
-import net.minecraft.util.ResourceLocation;
 import vazkii.patchouli.api.IComponentProcessor;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.BookPage;

--- a/src/main/java/vazkii/patchouli/client/book/page/PageText.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageText.java
@@ -45,7 +45,7 @@ public class PageText extends PageWithText {
 			}
 			
 			parent.drawCenteredStringNoShadow(parent.getEntry().getName(), GuiBook.PAGE_WIDTH / 2, renderedSmol ? -3 : 0, book.headerColor);
-			parent.drawSeparator(book, 0, 12);
+			GuiBook.drawSeparator(book, 0, 12);
 		}
 
 		else if(title != null && !title.isEmpty())

--- a/src/main/java/vazkii/patchouli/client/book/template/BookTemplate.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/BookTemplate.java
@@ -3,6 +3,7 @@ package vazkii.patchouli.client.book.template;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.google.gson.annotations.SerializedName;
@@ -25,7 +26,7 @@ import vazkii.patchouli.common.book.Book;
 
 public class BookTemplate {
 	
-	public static final HashMap<String, Class<? extends TemplateComponent>> componentTypes = new HashMap();
+	public static final HashMap<String, Class<? extends TemplateComponent>> componentTypes = new HashMap<>();
 	
 	static {
 		registerComponent("text", ComponentText.class);
@@ -39,8 +40,8 @@ public class BookTemplate {
 	}
 
 	@SerializedName("include")
-	List<TemplateInclusion> inclusions = new ArrayList();
-	List<TemplateComponent> components = new ArrayList();
+	List<TemplateInclusion> inclusions = new ArrayList<>();
+	List<TemplateComponent> components = new ArrayList<>();
 	
 	@SerializedName("processor")
 	String processorClass;
@@ -73,7 +74,7 @@ public class BookTemplate {
 			return;
 		
 		createProcessor();
-		components.removeIf(c -> c == null);
+		components.removeIf(Objects::isNull);
 		
 		if(processor != null) {
 			IVariableProvider processorVars = variables;

--- a/src/main/java/vazkii/patchouli/client/book/template/JsonVariableWrapper.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/JsonVariableWrapper.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonPrimitive;
 
 import vazkii.patchouli.api.IVariableProvider;
 
-public final class JsonVariableWrapper implements IVariableProvider {
+public final class JsonVariableWrapper implements IVariableProvider<String> {
 
 	private final JsonObject source;
 	

--- a/src/main/java/vazkii/patchouli/client/book/template/TemplateInclusion.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/TemplateInclusion.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import com.google.gson.annotations.SerializedName;
 
-import net.minecraft.world.gen.structure.template.ITemplateProcessor;
 import vazkii.patchouli.api.IComponentProcessor;
 import vazkii.patchouli.api.IVariableProvider;
 
@@ -17,10 +16,10 @@ public class TemplateInclusion {
 	public String template;
 	public String as;
 	@SerializedName("using")
-	public Map<String, String> map = new HashMap();
+	public Map<String, String> map = new HashMap<>();
 	public int x, y;
 
-	transient List<String> visitedTemplates = new ArrayList();
+	transient List<String> visitedTemplates = new ArrayList<>();
 	
 	public void upperMerge(TemplateInclusion upper) {
 		if(upper == null)
@@ -29,7 +28,7 @@ public class TemplateInclusion {
 		if(upper.visitedTemplates.contains(template))
 			throw new IllegalArgumentException("Breaking when include template " + template + ", circular dependencies aren't allowed (stack = " + upper.visitedTemplates + ")");
 		
-		visitedTemplates = new ArrayList(upper.visitedTemplates);
+		visitedTemplates = new ArrayList<>(upper.visitedTemplates);
 		visitedTemplates.add(template);
 		as = upper.realName(as);
 		x += upper.x;
@@ -81,8 +80,8 @@ public class TemplateInclusion {
 		return var;
 	}
 	
-	public IVariableProvider wrapProvider(IVariableProvider<String> provider) {
-		return new IVariableProvider() {
+	public IVariableProvider<String> wrapProvider(IVariableProvider<String> provider) {
+		return new IVariableProvider<String>() {
 			
 			@Override
 			public boolean has(String key) {

--- a/src/main/java/vazkii/patchouli/client/book/template/component/ComponentCustom.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/component/ComponentCustom.java
@@ -1,13 +1,8 @@
 package vazkii.patchouli.client.book.template.component;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import com.google.gson.JsonPrimitive;
 import com.google.gson.annotations.SerializedName;
 
 import vazkii.patchouli.api.ICustomComponent;
-import vazkii.patchouli.api.IVariableProvider;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.BookPage;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;

--- a/src/main/java/vazkii/patchouli/client/book/template/component/ComponentEntity.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/component/ComponentEntity.java
@@ -4,12 +4,12 @@ import java.lang.reflect.Constructor;
 
 import com.google.gson.annotations.SerializedName;
 
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.nbt.NBTException;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import vazkii.patchouli.api.VariableHolder;
@@ -29,14 +29,14 @@ public class ComponentEntity extends TemplateComponent {
 	float renderSize = 100;
 	
 	transient boolean errored;
-	transient Constructor<Entity> constructor;
+	transient Constructor<? extends Entity> constructor;
 	transient Entity entity;
 	transient float renderScale, offset;
 	transient NBTTagCompound nbt;
 
 	@Override
 	public void build(BookPage page, BookEntry entry, int pageNum) {
-		String nbtStr = "";
+		String nbtStr;
 		int nbtStart = entityId.indexOf("{");
 		if(nbtStart > 0) {
 			nbtStr = entityId.substring(nbtStart).replaceAll("([^\\\\])'", "$1\"").replaceAll("\\\\'", "'");
@@ -49,7 +49,7 @@ public class ComponentEntity extends TemplateComponent {
 			}
 		}
 		
-		Class clazz = ForgeRegistries.ENTITIES.getValue(new ResourceLocation(entityId)).getEntityClass();
+		Class<? extends Entity> clazz = ForgeRegistries.ENTITIES.getValue(new ResourceLocation(entityId)).getEntityClass();
 		try {
 			constructor = clazz.getConstructor(World.class);
 		} catch(Exception e) {
@@ -65,7 +65,7 @@ public class ComponentEntity extends TemplateComponent {
 	@Override
 	public void render(BookPage page, int mouseX, int mouseY, float pticks) {
 		if(errored)
-			page.fontRenderer.drawStringWithShadow(I18n.translateToLocal("patchouli.gui.lexicon.loading_error"), x, y, 0xFF0000);
+			page.fontRenderer.drawStringWithShadow(I18n.format("patchouli.gui.lexicon.loading_error"), x, y, 0xFF0000);
 		
 		if(entity != null)
 			renderEntity(page.mc.world, ClientTicker.total);

--- a/src/main/java/vazkii/patchouli/client/book/template/component/ComponentImage.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/component/ComponentImage.java
@@ -2,6 +2,7 @@ package vazkii.patchouli.client.book.template.component;
 
 import com.google.gson.annotations.SerializedName;
 
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
 import vazkii.patchouli.api.VariableHolder;
@@ -43,7 +44,7 @@ public class ComponentImage extends TemplateComponent {
 		GlStateManager.scale(scale, scale, scale);
 		GlStateManager.color(1F, 1F, 1F, 1F);
 		GlStateManager.enableBlend();
-		page.parent.drawModalRectWithCustomSizedTexture(0, 0, u, v, width, height, textureWidth, textureHeight);
+		Gui.drawModalRectWithCustomSizedTexture(0, 0, u, v, width, height, textureWidth, textureHeight);
 		GlStateManager.popMatrix();
 	}
 

--- a/src/main/java/vazkii/patchouli/client/book/template/component/ComponentItemStack.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/component/ComponentItemStack.java
@@ -2,6 +2,7 @@ package vazkii.patchouli.client.book.template.component;
 
 import com.google.gson.annotations.SerializedName;
 
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import vazkii.patchouli.api.VariableHolder;
@@ -37,7 +38,7 @@ public class ComponentItemStack extends TemplateComponent {
 			GlStateManager.enableBlend();
 			GlStateManager.color(1F, 1F, 1F, 1F);
 			page.mc.renderEngine.bindTexture(page.book.craftingResource);
-			page.parent.drawModalRectWithCustomSizedTexture(x - 4, y - 4, 83, 71, 24, 24, 128, 128);
+			Gui.drawModalRectWithCustomSizedTexture(x - 4, y - 4, 83, 71, 24, 24, 128, 128);
 		}
 		
 		page.renderItem(x, y, mouseX, mouseY, stack);

--- a/src/main/java/vazkii/patchouli/client/book/template/component/ComponentSeparator.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/component/ComponentSeparator.java
@@ -2,6 +2,7 @@ package vazkii.patchouli.client.book.template.component;
 
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.BookPage;
+import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.template.TemplateComponent;
 
 public class ComponentSeparator extends TemplateComponent {
@@ -16,7 +17,7 @@ public class ComponentSeparator extends TemplateComponent {
 	
 	@Override
 	public void render(BookPage page, int mouseX, int mouseY, float pticks) {
-		page.parent.drawSeparator(page.book, x, y);
+		GuiBook.drawSeparator(page.book, x, y);
 	}
 	
 }

--- a/src/main/java/vazkii/patchouli/client/handler/MultiblockVisualizationHandler.java
+++ b/src/main/java/vazkii/patchouli/client/handler/MultiblockVisualizationHandler.java
@@ -21,6 +21,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.EnumDyeColor;
@@ -29,7 +30,6 @@ import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult.Type;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
@@ -40,9 +40,9 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
 import vazkii.patchouli.api.IStateMatcher;
 import vazkii.patchouli.client.base.ClientTicker;
 import vazkii.patchouli.client.base.PersistentData.DataHolder.BookData.Bookmark;
-import vazkii.patchouli.common.util.ReflectionUtil;
 import vazkii.patchouli.common.multiblock.Multiblock;
 import vazkii.patchouli.common.multiblock.StateMatcher;
+import vazkii.patchouli.common.util.ReflectionUtil;
 import vazkii.patchouli.common.util.RotationUtil;
 
 public class MultiblockVisualizationHandler {
@@ -121,7 +121,7 @@ public class MultiblockVisualizationHandler {
 			int top = y + 10;
 
 			if(timeComplete > 0) {
-				String s = I18n.translateToLocal("patchouli.gui.lexicon.structure_complete");
+				String s = I18n.format("patchouli.gui.lexicon.structure_complete");
 				GlStateManager.pushMatrix();
 				GlStateManager.translate(0, Math.min(height + 5, animTime), 0);
 				mc.fontRenderer.drawStringWithShadow(s, x - mc.fontRenderer.getStringWidth(s) / 2, top + height - 10, 0x00FF00);
@@ -138,7 +138,7 @@ public class MultiblockVisualizationHandler {
 			drawGradientRect(left, top, left + progressWidth, top + height, color, color2);
 
 			if(!isAnchored) {
-				String s = I18n.translateToLocal("patchouli.gui.lexicon.not_anchored");
+				String s = I18n.format("patchouli.gui.lexicon.not_anchored");
 				mc.fontRenderer.drawStringWithShadow(s, x - mc.fontRenderer.getStringWidth(s) / 2, top + height + 8, 0xFFFFFF);
 			} else {
 				if(lookingState != null) {
@@ -160,7 +160,7 @@ public class MultiblockVisualizationHandler {
 					String progress = blocksDone + "/" + blocks;
 					
 					if(blocksDone == blocks && airFilled > 0) {
-						progress = I18n.translateToLocal("patchouli.gui.lexicon.needs_air");
+						progress = I18n.format("patchouli.gui.lexicon.needs_air");
 						color = 0xDA4E3F;
 						mult *= 2;
 						posx -= width / 2;

--- a/src/main/java/vazkii/patchouli/common/base/Patchouli.java
+++ b/src/main/java/vazkii/patchouli/common/base/Patchouli.java
@@ -2,9 +2,6 @@ package vazkii.patchouli.common.base;
 
 import java.lang.management.ManagementFactory;
 
-import net.minecraftforge.common.config.Config;
-import net.minecraftforge.common.config.ConfigManager;
-import net.minecraftforge.fml.client.event.ConfigChangedEvent.OnConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.Mod.Instance;
@@ -12,7 +9,6 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @Mod(modid = Patchouli.MOD_ID, name = Patchouli.MOD_NAME)
 public class Patchouli {

--- a/src/main/java/vazkii/patchouli/common/base/PatchouliAPIImpl.java
+++ b/src/main/java/vazkii/patchouli/common/base/PatchouliAPIImpl.java
@@ -44,7 +44,7 @@ public class PatchouliAPIImpl implements IPatchouliAPI {
 
 	@Override
 	public void openBookGUI(EntityPlayerMP player, ResourceLocation book) {
-		NetworkHandler.INSTANCE.sendTo(new MessageOpenBookGui(book.toString()), (EntityPlayerMP) player);
+		NetworkHandler.INSTANCE.sendTo(new MessageOpenBookGui(book.toString()), player);
 	}
 	
 	@Override

--- a/src/main/java/vazkii/patchouli/common/base/PatchouliConfig.java
+++ b/src/main/java/vazkii/patchouli/common/base/PatchouliConfig.java
@@ -26,7 +26,7 @@ public class PatchouliConfig {
 	@Comment("Enable testing mode. By default this doesn't do anything, but you can use the config flag in your books if you want.\nConfig Flag: testing_mode")
 	public static boolean testingMode = false;
 	
-	@Ignore private static Map<String, Boolean> configFlags = new HashMap();
+	@Ignore private static Map<String, Boolean> configFlags = new HashMap<>();
 	@Ignore private transient static boolean firstChange = true;
 	
 	public static void preInit() {
@@ -48,9 +48,9 @@ public class PatchouliConfig {
 	
 	public static boolean getConfigFlag(String name) {
 		if(name.startsWith("&"))
-			return getConfigFlagAND(name.replaceAll("\\&|\\|", "").split(","));
+			return getConfigFlagAND(name.replaceAll("[&|]", "").split(","));
 		if(name.startsWith("|"))
-			return getConfigFlagOR(name.replaceAll("\\&|\\|", "").split(","));
+			return getConfigFlagOR(name.replaceAll("[&|]", "").split(","));
 			
 		boolean target = true;
 		if(name.startsWith("!")) {
@@ -58,9 +58,8 @@ public class PatchouliConfig {
 			target = false;
 		}
 		name = name.trim().toLowerCase();
-		
-		boolean status = (configFlags.containsKey(name) && configFlags.get(name)) == target;
-		return status;
+
+		return (configFlags.containsKey(name) && configFlags.get(name)) == target;
 	}
 	
 	public static boolean getConfigFlagAND(String[] tokens) {

--- a/src/main/java/vazkii/patchouli/common/book/Book.java
+++ b/src/main/java/vazkii/patchouli/common/book/Book.java
@@ -15,6 +15,7 @@ import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.patchouli.client.book.BookContents;
+import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.ExternalBookContents;
 import vazkii.patchouli.common.base.Patchouli;
 import vazkii.patchouli.common.handler.AdvancementSyncHandler;
@@ -26,7 +27,7 @@ public class Book {
 	public static final String DEFAULT_MODEL = Patchouli.PREFIX + "book_brown";
 	public static final ModelResourceLocation DEFAULT_MODEL_RES = new ModelResourceLocation(DEFAULT_MODEL, "inventory");
 	
-	private static final Map<String, String> DEFAULT_MACROS = new HashMap() {{
+	private static final Map<String, String> DEFAULT_MACROS = new HashMap<String, String>() {{
 		put("$(list", "$(li"); //  The lack of ) is intended
 		put("/$", "$()");
 		put("<br>", "$(br)");
@@ -48,7 +49,7 @@ public class Book {
 	public transient int textColor, headerColor, nameplateColor, linkColor, linkHoverColor, progressBarColor, progressBarBackground;
 	
 	public transient boolean isExtension = false;
-	public transient List<Book> extensions = new LinkedList();
+	public transient List<Book> extensions = new LinkedList<>();
 	public transient Book extensionTarget;
 	
 	public transient boolean isExternal;
@@ -60,7 +61,7 @@ public class Book {
 	public String landingText = "patchouli.gui.lexicon.landing_info";
 
 	@SerializedName("advancement_namespaces")
-	public List<String> advancementNamespaces = new ArrayList();
+	public List<String> advancementNamespaces = new ArrayList<>();
 
 	@SerializedName("book_texture")
 	public String bookTexture = Patchouli.PREFIX + "textures/gui/book_brown.png";
@@ -119,7 +120,7 @@ public class Book {
 	@SerializedName("allow_extensions")
 	public boolean allowExtensions = true;
 	
-	public Map<String, String> macros = new HashMap();
+	public Map<String, String> macros = new HashMap<>();
 	
 	public void build(ModContainer owner, ResourceLocation resource, boolean external) {
 		this.owner = owner;
@@ -224,7 +225,7 @@ public class Book {
 	
 	@SideOnly(Side.CLIENT)
 	public void reloadLocks(boolean reset) {
-		contents.entries.values().forEach((e) -> e.updateLockStatus());
+		contents.entries.values().forEach(BookEntry::updateLockStatus);
 		contents.categories.values().forEach((c) -> c.updateLockStatus(true));
 		
 		if(reset)

--- a/src/main/java/vazkii/patchouli/common/book/BookRegistry.java
+++ b/src/main/java/vazkii/patchouli/common/book/BookRegistry.java
@@ -6,7 +6,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,7 +15,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.fml.common.Loader;
@@ -31,7 +29,7 @@ public class BookRegistry {
 	public static final BookRegistry INSTANCE = new BookRegistry();
 	public static final String BOOKS_LOCATION = Patchouli.MOD_ID + "_books";
 
-	public final Map<ResourceLocation, Book> books = new HashMap();
+	public final Map<ResourceLocation, Book> books = new HashMap<>();
 	public Gson gson;
 
 	private BookRegistry() { 
@@ -40,7 +38,7 @@ public class BookRegistry {
 
 	public void init() {
 		List<ModContainer> mods = Loader.instance().getActiveModList();
-		Map<Pair<ModContainer, ResourceLocation>, String> foundBooks = new HashMap();
+		Map<Pair<ModContainer, ResourceLocation>, String> foundBooks = new HashMap<>();
 
 		mods.forEach((mod) -> {
 			String id = mod.getModId();
@@ -51,7 +49,7 @@ public class BookRegistry {
 							String relPath = fileStr.substring(fileStr.indexOf(BOOKS_LOCATION) + BOOKS_LOCATION.length() + 1);
 							String bookName = relPath.substring(0, relPath.indexOf("/"));
 
-							if(bookName.indexOf("/") > -1) {
+							if(bookName.contains("/")) {
 								(new IllegalArgumentException("Ignored book.json @ " + file)).printStackTrace();
 								return true;
 							}

--- a/src/main/java/vazkii/patchouli/common/handler/AdvancementSyncHandler.java
+++ b/src/main/java/vazkii/patchouli/common/handler/AdvancementSyncHandler.java
@@ -20,7 +20,7 @@ import vazkii.patchouli.common.network.message.MessageSyncAdvancements;
 
 public final class AdvancementSyncHandler {
 
-	public static Set<String> trackedNamespaces = new HashSet();
+	public static Set<String> trackedNamespaces = new HashSet<>();
 	
 	public static List<ResourceLocation> syncedAdvancements = null;
 
@@ -49,7 +49,7 @@ public final class AdvancementSyncHandler {
 			AdvancementManager manager = player.getServer().getAdvancementManager();
 			Iterable<Advancement> allAdvancements = manager.getAdvancements();
 			
-			syncedAdvancements = new ArrayList();
+			syncedAdvancements = new ArrayList<>();
 			for(Advancement a : allAdvancements)
 				if(trackedNamespaces.contains(a.getId().getResourceDomain()))
 					syncedAdvancements.add(a.getId());
@@ -63,7 +63,7 @@ public final class AdvancementSyncHandler {
 		
 		AdvancementManager manager = player.getServer().getAdvancementManager();
 		
-		List<String> completed = new LinkedList();
+		List<String> completed = new LinkedList<>();
 		for(ResourceLocation res : syncedAdvancements) {
 			Advancement adv = manager.getAdvancement(res);
 			AdvancementProgress p = advancements.getProgress(adv);
@@ -71,7 +71,7 @@ public final class AdvancementSyncHandler {
 				completed.add(res.toString());
 		}
 		
-		String[] completedArr = completed.toArray(new String[completed.size()]);
+		String[] completedArr = completed.toArray(new String[0]);
 		NetworkHandler.INSTANCE.sendTo(new MessageSyncAdvancements(completedArr, showToast), player);
 	}
 	

--- a/src/main/java/vazkii/patchouli/common/item/ItemModBook.java
+++ b/src/main/java/vazkii/patchouli/common/item/ItemModBook.java
@@ -134,7 +134,7 @@ public class ItemModBook extends Item {
 		ItemStack stack = playerIn.getHeldItem(handIn);
 		Book book = getBook(stack);
 		if(book == null)
-			return new ActionResult<ItemStack>(EnumActionResult.FAIL, stack);
+			return new ActionResult<>(EnumActionResult.FAIL, stack);
 
 		if(playerIn instanceof EntityPlayerMP) {
 			NetworkHandler.INSTANCE.sendTo(new MessageOpenBookGui(book.resourceLoc.toString()), (EntityPlayerMP) playerIn);
@@ -142,7 +142,7 @@ public class ItemModBook extends Item {
 			worldIn.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, sfx, SoundCategory.PLAYERS, 1F, (float) (0.7 + Math.random() * 0.4));
 		}
 
-		return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, stack);
+		return new ActionResult<>(EnumActionResult.SUCCESS, stack);
 	}
 
 

--- a/src/main/java/vazkii/patchouli/common/item/PatchouliItems.java
+++ b/src/main/java/vazkii/patchouli/common/item/PatchouliItems.java
@@ -13,7 +13,6 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import vazkii.patchouli.common.base.Patchouli;
 import vazkii.patchouli.common.book.Book;
 import vazkii.patchouli.common.book.BookRegistry;
 
@@ -39,9 +38,9 @@ public class PatchouliItems {
 	}
 
 	private static void bindBookModel() {
-		List<ModelResourceLocation> models = new LinkedList();
+		List<ModelResourceLocation> models = new LinkedList<>();
 		BookRegistry.INSTANCE.books.values().forEach(b -> models.add(new ModelResourceLocation(b.model, "inventory")));
-		ModelBakery.registerItemVariants(book, models.toArray(new ModelResourceLocation[models.size()]));
+		ModelBakery.registerItemVariants(book, models.toArray(new ModelResourceLocation[0]));
 
 		ModelLoader.setCustomMeshDefinition(book, (stack) -> {
 			Book book = ItemModBook.getBook(stack);

--- a/src/main/java/vazkii/patchouli/common/multiblock/Multiblock.java
+++ b/src/main/java/vazkii/patchouli/common/multiblock/Multiblock.java
@@ -150,11 +150,11 @@ public class Multiblock implements IMultiblock {
 		if(targets.length % 2 == 1)
 			throw new IllegalArgumentException("Illegal argument length for targets array " + targets.length);
 
-		Map<Character, IStateMatcher> stateMap = new HashMap();
+		Map<Character, IStateMatcher> stateMap = new HashMap<>();
 		for(int i = 0; i < targets.length / 2; i++) {
 			char c = (Character) targets[i * 2];
 			Object o = targets[i * 2 + 1];
-			IStateMatcher state = null;
+			IStateMatcher state;
 
 			if(o instanceof Block)
 				state = StateMatcher.fromBlockLoose((Block) o);

--- a/src/main/java/vazkii/patchouli/common/multiblock/MultiblockRegistry.java
+++ b/src/main/java/vazkii/patchouli/common/multiblock/MultiblockRegistry.java
@@ -12,7 +12,7 @@ import vazkii.patchouli.common.base.Patchouli;
 
 public class MultiblockRegistry {
 
-	public static final HashMap<ResourceLocation, IMultiblock> MULTIBLOCKS = new HashMap();
+	public static final HashMap<ResourceLocation, IMultiblock> MULTIBLOCKS = new HashMap<>();
 
 	public static IMultiblock crucible;
 
@@ -29,7 +29,7 @@ public class MultiblockRegistry {
 					{ "SSS", "SFS", "SSS" }},
 						'0', Blocks.CAULDRON,
 						'F', Blocks.FIRE,
-						'S', api.predicateMatcher(Blocks.STONEBRICK, (state) -> state.getBlock().isOpaqueCube(state) && state.getMaterial() == Material.ROCK),
+						'S', api.predicateMatcher(Blocks.STONEBRICK, (state) -> state.isOpaqueCube() && state.getMaterial() == Material.ROCK),
 						' ', api.anyMatcher()))
 				.setSymmetrical(true);
 	}

--- a/src/main/java/vazkii/patchouli/common/multiblock/SerializedMultiblock.java
+++ b/src/main/java/vazkii/patchouli/common/multiblock/SerializedMultiblock.java
@@ -3,8 +3,6 @@ package vazkii.patchouli.common.multiblock;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.gson.annotations.SerializedName;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
@@ -13,7 +11,7 @@ import net.minecraft.util.ResourceLocation;
 public class SerializedMultiblock {
 
 	String[][] pattern = new String[0][0];
-	Map<String, String> mapping = new HashMap();
+	Map<String, String> mapping = new HashMap<>();
 
 	boolean symmetrical = false;
 	int[] offset = new int[] { 0, 0, 0 };

--- a/src/main/java/vazkii/patchouli/common/network/NetworkHandler.java
+++ b/src/main/java/vazkii/patchouli/common/network/NetworkHandler.java
@@ -13,6 +13,8 @@ package vazkii.patchouli.common.network;
 import io.netty.buffer.ByteBuf;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import net.minecraftforge.fml.relauncher.Side;
 import vazkii.patchouli.common.base.Patchouli;
@@ -48,7 +50,7 @@ public class NetworkHandler {
 			ByteBufUtils.writeUTF8String(buf, arr[i]);
 	}
 	
-	public static void register(Class clazz, Side handlerSide) {
+	public static <T extends IMessage & IMessageHandler<T, IMessage>> void register(Class<T> clazz, Side handlerSide) {
 		INSTANCE.registerMessage(clazz, clazz, i++, handlerSide);
 	}
 	

--- a/src/main/java/vazkii/patchouli/common/network/message/MessageOpenBookGui.java
+++ b/src/main/java/vazkii/patchouli/common/network/message/MessageOpenBookGui.java
@@ -4,7 +4,6 @@ import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import vazkii.patchouli.client.base.ClientAdvancements;
 import vazkii.patchouli.client.base.ClientTicker;
 import vazkii.patchouli.client.book.ClientBookRegistry;
 import vazkii.patchouli.common.network.NetworkMessage;
@@ -22,9 +21,7 @@ public class MessageOpenBookGui extends NetworkMessage<MessageOpenBookGui> {
 	@Override
 	@SideOnly(Side.CLIENT)
 	public IMessage handleMessage(MessageContext context) {
-		ClientTicker.addAction(() -> {
-			ClientBookRegistry.INSTANCE.displayBookGui(book);
-		});
+		ClientTicker.addAction(() -> ClientBookRegistry.INSTANCE.displayBookGui(book));
 		
 		return null;
 	}

--- a/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
+++ b/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
@@ -1,12 +1,9 @@
 package vazkii.patchouli.common.util;
 
-import java.util.HashMap;
-
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.nbt.NBTException;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
 public class ItemStackUtil {

--- a/src/main/java/vazkii/patchouli/common/util/ReflectionUtil.java
+++ b/src/main/java/vazkii/patchouli/common/util/ReflectionUtil.java
@@ -5,7 +5,7 @@ import net.minecraftforge.fml.common.asm.transformers.deobf.FMLDeobfuscatingRema
 import java.lang.reflect.Field;
 
 public class ReflectionUtil {
-	public static Field accessField(Class owner, String srgName, String descriptor) throws NoSuchFieldException {
+	public static Field accessField(Class<?> owner, String srgName, String descriptor) throws NoSuchFieldException {
 		Field result = owner.getDeclaredField(FMLDeobfuscatingRemapper.INSTANCE.mapFieldName(owner.getCanonicalName().replace('.', '/'), srgName, descriptor));
 		result.setAccessible(true);
 		return result;


### PR DESCRIPTION
Brings down the number of compile warnings (with `-Xlint:all`) from ~250 to 28. 
Cleaned up things that cause warnings:
* lots of raw types (things like no `<>` in list/map construction, etc)
* some unchecked assignments and generics stuff
* deprecated method usage (mostly that client I18n is now used in the client package)
* static methods referenced through instances

Other cleanups:
* removed unused imports and casts
* simplified a few lambdas
* some other minor stuff

Remaining things: there's one use of common I18n in the book item, variable providers and network message readers/writers are still using mostly the raw type, and serializable classes do not have the UID defined.