### PR TITLE
Make SerializedMultiblock variables public to allow the VariableAssigner access.

### DIFF
--- a/src/main/java/vazkii/patchouli/common/multiblock/SerializedMultiblock.java
+++ b/src/main/java/vazkii/patchouli/common/multiblock/SerializedMultiblock.java
@@ -7,10 +7,13 @@ import net.minecraft.block.Block;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
+import vazkii.patchouli.api.VariableHolder;
 
 public class SerializedMultiblock {
 
+	@VariableHolder
 	public String[][] pattern = new String[0][0];
+	@VariableHolder
 	public Map<String, String> mapping = new HashMap<>();
 
 	boolean symmetrical = false;

--- a/src/main/java/vazkii/patchouli/common/multiblock/SerializedMultiblock.java
+++ b/src/main/java/vazkii/patchouli/common/multiblock/SerializedMultiblock.java
@@ -10,8 +10,8 @@ import net.minecraft.util.ResourceLocation;
 
 public class SerializedMultiblock {
 
-	String[][] pattern = new String[0][0];
-	Map<String, String> mapping = new HashMap<>();
+	public String[][] pattern = new String[0][0];
+	public Map<String, String> mapping = new HashMap<>();
 
 	boolean symmetrical = false;
 	int[] offset = new int[] { 0, 0, 0 };

--- a/src/main/java/vazkii/patchouli/common/multiblock/SerializedMultiblock.java
+++ b/src/main/java/vazkii/patchouli/common/multiblock/SerializedMultiblock.java
@@ -11,7 +11,6 @@ import vazkii.patchouli.api.VariableHolder;
 
 public class SerializedMultiblock {
 
-	@VariableHolder
 	public String[][] pattern = new String[0][0];
 	@VariableHolder
 	public Map<String, String> mapping = new HashMap<>();


### PR DESCRIPTION
In the [VariableAssigner](https://github.com/Vazkii/Patchouli/blob/master/src/main/java/vazkii/patchouli/client/book/template/VariableAssigner.java#L29) the method `Class::getFields` is used which respects field accessiblity (as opposed to `Class::getDeclaredFields` which goes up inheritance as well) this is acceptable, you probably don't want to parse too many fields. 
Due to this though, the package-private fields in SerializedMultiblock disallowed the assigner from retrieving those fields to be parsed, so I here I have made them public.
