### PR TITLE
Add a validation step for advancement keys to help with debugging.

### DIFF
--- a/src/main/java/vazkii/patchouli/client/book/BookPage.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookPage.java
@@ -15,6 +15,7 @@ import vazkii.patchouli.client.base.ClientAdvancements;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
 import vazkii.patchouli.common.base.PatchouliConfig;
 import vazkii.patchouli.common.book.Book;
+import vazkii.patchouli.common.util.ValidationUtils;
 
 public abstract class BookPage {
 
@@ -35,6 +36,7 @@ public abstract class BookPage {
 		this.book = entry.book;
 		this.entry = entry;
 		this.pageNum = pageNum;
+		ValidationUtils.validateAdvancement(this.advancement);
 	}
 	
 	public void onDisplayed(GuiBookEntry parent, int left, int top) { 

--- a/src/main/java/vazkii/patchouli/client/book/template/BookTemplate.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/BookTemplate.java
@@ -24,6 +24,7 @@ import vazkii.patchouli.client.book.template.component.ComponentSeparator;
 import vazkii.patchouli.client.book.template.component.ComponentText;
 import vazkii.patchouli.client.book.template.component.ComponentTooltip;
 import vazkii.patchouli.common.book.Book;
+import vazkii.patchouli.common.util.ValidationUtils;
 
 public class BookTemplate {
 	
@@ -110,7 +111,10 @@ public class BookTemplate {
 	
 	public void build(BookPage page, BookEntry entry, int pageNum) {
 		if(compiled)
-			components.forEach(c -> c.build(page, entry, pageNum));
+			components.forEach(c -> {
+				ValidationUtils.validateAdvancement(c.advancement);
+				c.build(page, entry, pageNum);
+			});
 	}
 	
 	public void onDisplayed(BookPage page, GuiBookEntry parent, int left, int top) {

--- a/src/main/java/vazkii/patchouli/common/util/ValidationUtils.java
+++ b/src/main/java/vazkii/patchouli/common/util/ValidationUtils.java
@@ -1,0 +1,31 @@
+package vazkii.patchouli.common.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementList;
+import net.minecraft.advancements.AdvancementManager;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
+
+import java.util.Set;
+
+public class ValidationUtils {
+
+    public static AdvancementList ADVANCEMENT_LIST = ReflectionHelper.getPrivateValue(AdvancementManager.class, null, 2);
+
+    public static boolean isValidAdvancement(String advancement) {
+        return ADVANCEMENT_LIST.getAdvancement(new ResourceLocation(advancement)) != null;
+    }
+
+
+
+    public static void validateAdvancement(String advancement) {
+        if(advancement != null && !advancement.isEmpty()) {
+            Set<Advancement> advancements = Sets.newHashSet(ADVANCEMENT_LIST.getAdvancements());
+            if(!advancements.isEmpty())
+                Preconditions.checkState(isValidAdvancement(advancement), "Invalid advancement:" + advancement);
+        }
+    }
+
+}


### PR DESCRIPTION
This is more of an experimental debug feature that I just want to see thoughts on it.
It adds validation for whether the advancement exists for an page/component.

This helps a lot with finding exactly why your page isn't unlocking when you expect it to.
Properly throwing an exception so the book error handler sees it.
![Example](https://cloud.primetoxinz.com/s/gjJcpbMswZQcBRC/preview)

Due to the fact that advancements load on World init rather than game init, it will only validate on a reload of the book in-game.

The one thing that is not ideal is the placement of the validation for Components, since there is no base build implementation to put it for all child classes I put it in the for each that calls it. 

Let me know what you think.

