### PR TITLE
Add event that fires when Patchouli reloads a book's contents

### DIFF
--- a/src/main/java/vazkii/patchouli/api/BookContentsReloadEvent.java
+++ b/src/main/java/vazkii/patchouli/api/BookContentsReloadEvent.java
@@ -1,0 +1,20 @@
+package vazkii.patchouli.api;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS} after a
+ * book is reloaded.
+ */
+public class BookContentsReloadEvent
+    extends Event {
+
+  public final ResourceLocation book;
+
+  public BookContentsReloadEvent(ResourceLocation book) {
+
+    this.book = book;
+  }
+}

--- a/src/main/java/vazkii/patchouli/api/BookDrawScreenEvent.java
+++ b/src/main/java/vazkii/patchouli/api/BookDrawScreenEvent.java
@@ -12,17 +12,18 @@ import net.minecraftforge.fml.common.eventhandler.Event;
  * custom compoenents should be drawn independently of what page a book
  * is currently on.
  */
-public class BookDrawScreenEvent extends Event {
+public class BookDrawScreenEvent
+		extends BookEvent {
 	
 	public final GuiScreen gui;
-	public final ResourceLocation book;
 	public final int mouseX;
 	public final int mouseY;
 	public final float partialTicks;
 	
 	public BookDrawScreenEvent(GuiScreen gui, ResourceLocation book, int mouseX, int mouseY, float partialTicks) {
+
+		super(book);
 		this.gui = gui;
-		this.book = book;
 		this.mouseX = mouseX;
 		this.mouseY = mouseY;
 		this.partialTicks = partialTicks;

--- a/src/main/java/vazkii/patchouli/api/BookEvent.java
+++ b/src/main/java/vazkii/patchouli/api/BookEvent.java
@@ -1,0 +1,15 @@
+package vazkii.patchouli.api;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public abstract class BookEvent
+    extends Event {
+
+  public final ResourceLocation book;
+
+  public BookEvent(ResourceLocation book) {
+
+    this.book = book;
+  }
+}

--- a/src/main/java/vazkii/patchouli/common/book/Book.java
+++ b/src/main/java/vazkii/patchouli/common/book/Book.java
@@ -11,9 +11,11 @@ import com.google.gson.annotations.SerializedName;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import vazkii.patchouli.api.BookContentsReloadEvent;
 import vazkii.patchouli.client.book.BookContents;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.ExternalBookContents;
@@ -200,8 +202,10 @@ public class Book {
 		if(contents == null)
 			contents = isExternal ? new ExternalBookContents(this) : new BookContents(this);
 	
-		if(!isExtension)
+		if(!isExtension) {
 			contents.reload(false);
+			MinecraftForge.EVENT_BUS.post(new BookContentsReloadEvent(this.bookResource));
+		}
 	}
 	
 	@SideOnly(Side.CLIENT)
@@ -224,6 +228,7 @@ public class Book {
 			}
 			
 			contents.reload(true);
+			MinecraftForge.EVENT_BUS.post(new BookContentsReloadEvent(this.bookResource));
 		}
 	}
 	


### PR DESCRIPTION
https://github.com/Vazkii/Patchouli/commit/2124368c9aadf8407ee2a62deb4c7f66c2af3ecc - Factors out a BookEvent class to be used by both book events.

https://github.com/Vazkii/Patchouli/commit/f9629dd2a107ecc91e676c69689b810b6cdeb977 - Adds a new book event that fires when Patchouli reloads a book's contents.