### PR TITLE
Add i18n book toggle, i18n variable function, custom entry colors

### DIFF
--- a/src/main/java/vazkii/patchouli/client/book/BookEntry.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookEntry.java
@@ -25,28 +25,32 @@ import vazkii.patchouli.common.util.ItemStackUtil.StackWrapper;
 
 public class BookEntry extends AbstractReadStateHolder implements Comparable<BookEntry> {
 
-	String name, category, flag;
+	private String name, category, flag;
 
 	@SerializedName("icon")
-	String iconRaw;
+	private String iconRaw;
 
-	boolean priority = false;
-	boolean secret = false;
+	private boolean priority = false;
+	private boolean secret = false;
 	@SerializedName("read_by_default")
-	boolean readByDefault = false;
-	BookPage[] pages;
-	String advancement, turnin;
-	int sortnum;
+	private boolean readByDefault = false;
+	private BookPage[] pages;
+	private String advancement, turnin;
+	private int sortnum;
+	@SerializedName("entry_color")
+	private String entryColorRaw;
 
-	transient ResourceLocation resource;
-	transient Book book, trueProvider;
-	transient BookCategory lcategory = null;
-	transient BookIcon icon = null;
-	transient List<BookPage> realPages = new ArrayList<>();
-	transient List<StackWrapper> relevantStacks = new LinkedList<>();
-	transient boolean locked;
+	private transient ResourceLocation resource;
+	transient Book book;
+	private transient Book trueProvider;
+	private transient BookCategory lcategory = null;
+	private transient BookIcon icon = null;
+	private transient List<BookPage> realPages = new ArrayList<>();
+	private transient List<StackWrapper> relevantStacks = new LinkedList<>();
+	private transient boolean locked;
+	private transient int entryColor;
 
-	transient boolean built;
+	private transient boolean built;
 
 	public String getName() {
 		return name;
@@ -62,7 +66,7 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 		List<BookPage> pages = getPages();
 		for (int i = 0; i < pages.size(); i++) {
 			BookPage page = pages.get(i);
-			if (page.anchor != null && anchor.equals(page.anchor))
+			if (anchor.equals(page.anchor))
 				return i;
 		}
 
@@ -123,6 +127,10 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 		return isSecret() && isLocked();
 	}
 
+	public int getEntryColor() {
+		return entryColor;
+	}
+
 	public ResourceLocation getResource() {
 		return resource;
 	}
@@ -173,6 +181,11 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 			return;
 
 		this.resource = resource;
+		if (entryColorRaw != null) {
+			this.entryColor = Integer.parseInt(entryColorRaw, 16);
+		} else {
+			this.entryColor = book.textColor;
+		}
 		for(int i = 0; i < pages.length; i++)
 			if(pages[i].canAdd(book)) {
 				realPages.add(pages[i]);

--- a/src/main/java/vazkii/patchouli/client/book/gui/BookTextRenderer.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/BookTextRenderer.java
@@ -3,21 +3,20 @@ package vazkii.patchouli.client.book.gui;
 import java.util.List;
 
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.resources.I18n;
 import vazkii.patchouli.client.book.text.BookTextParser;
 import vazkii.patchouli.client.book.text.Word;
 import vazkii.patchouli.common.book.Book;
 
 public class BookTextRenderer {
-	final Book book;
-	final GuiBook gui;
-	final FontRenderer font;
-	final String text;
-	final int x, y, width;
-	final int spaceWidth;
-	final int lineHeight;
-	final int baseColor;
+	private final Book book;
+	private final GuiBook gui;
+	private final String text;
+	private final int x, y, width;
+	private final int lineHeight;
+	private final int baseColor;
 
-	List<Word> words;
+	private List<Word> words;
 	
 	public BookTextRenderer(GuiBook gui, String text, int x, int y) {
 		this(gui, text, x, y, GuiBook.PAGE_WIDTH, GuiBook.TEXT_LINE_HEIGHT, gui.book.textColor);
@@ -26,12 +25,14 @@ public class BookTextRenderer {
 	public BookTextRenderer(GuiBook gui, String text, int x, int y, int width, int lineHeight, int baseColor) {
 		this.book = gui.book;
 		this.gui = gui;
-		this.font = gui.getMinecraft().fontRenderer;
-		this.text = text;
+		if (book.i18n) {
+			this.text = I18n.format(text);
+		} else {
+			this.text = text;
+		}
 		this.x = x;
 		this.y = y;
 		this.width = width;
-		this.spaceWidth = font.getStringWidth(" ");
 		this.lineHeight = lineHeight;
 		this.baseColor = baseColor;
 		

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonEntry.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonEntry.java
@@ -17,9 +17,9 @@ public class GuiButtonEntry extends Button {
 	private static final int ANIM_TIME = 5;
 
 	GuiBook parent;
-	BookEntry entry;
-	int i;
-	float timeHovered;
+	private BookEntry entry;
+	private int i;
+	private float timeHovered;
 
 	public GuiButtonEntry(GuiBook parent, int x, int y, BookEntry entry, int i, Button.IPressable onPress) {
 		super(x, y, GuiBook.PAGE_WIDTH, 10, "", onPress);
@@ -53,20 +53,24 @@ public class GuiButtonEntry extends Button {
 			
 			GlStateManager.scalef(2F, 2F, 2F);
 
-			int color = parent.book.textColor;
 			String name = (entry.isPriority() ? TextFormatting.ITALIC : "") + entry.getName();
 			if(locked) {
 				name = I18n.format("patchouli.gui.lexicon.locked");
-				color = 0x77000000 | (parent.book.textColor & 0x00FFFFFF);
 			}
-			if(entry.isSecret())
-				color = 0xAA000000 | (parent.book.textColor & 0x00FFFFFF); 
-			
+			int color = getColor();
 			entry.getBook().getFont().drawString(name, x + 12, y, color);
 			
 			if(!entry.isLocked())
 				GuiBook.drawMarking(parent.book, x + width - 5, y + 1, entry.hashCode(), entry.getReadState());
 		}
+	}
+	
+	private int getColor() {
+		if (entry.isSecret()) 
+			return 0xAA000000 | (parent.book.textColor & 0x00FFFFFF);
+		if (entry.isLocked())
+			return 0x77000000 | (parent.book.textColor & 0x00FFFFFF);
+		return entry.getEntryColor();
 	}
 	
 	@Override

--- a/src/main/java/vazkii/patchouli/client/book/template/VariableAssigner.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/VariableAssigner.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.minecraft.client.resources.I18n;
 import org.apache.commons.lang3.text.WordUtils;
 
 import net.minecraft.item.ItemStack;
@@ -45,6 +46,7 @@ public class VariableAssigner {
 		FUNCTIONS.put("exists", VariableAssigner::exists);
 		FUNCTIONS.put("iexists", VariableAssigner::iexists);
 		FUNCTIONS.put("inv", VariableAssigner::inv);
+		FUNCTIONS.put("i18n", I18n::format);
 	}
 
 	public static void assignVariableHolders(Object object, IVariableProvider<String> variables, IComponentProcessor processor, TemplateInclusion encapsulation) {

--- a/src/main/java/vazkii/patchouli/common/book/Book.java
+++ b/src/main/java/vazkii/patchouli/common/book/Book.java
@@ -128,6 +128,8 @@ public class Book {
 	@SerializedName("allow_extensions")
 	public boolean allowExtensions = true;
 	
+	public boolean i18n = false;
+	
 	public Map<String, String> macros = new HashMap<>();
 	
 	public void build(IModInfo owner,  Class<?> ownerClass, ResourceLocation resource, boolean external) {

--- a/src/main/resources/data/patchouli/patchouli_books/testbook2/book.json
+++ b/src/main/resources/data/patchouli/patchouli_books/testbook2/book.json
@@ -15,5 +15,6 @@
 	},
 	"model": "patchouli:book_green",
 	"creative_tab": "decorations",
-	"advancements_tab": "patchouli"
+	"advancements_tab": "patchouli",
+	"i18n": true
 }

--- a/src/main/resources/data/patchouli/patchouli_books/testbook2/en_us/entries/intro/preface.json
+++ b/src/main/resources/data/patchouli/patchouli_books/testbook2/en_us/entries/intro/preface.json
@@ -4,10 +4,15 @@
 	"category": "intro",
 	"priority": true,
 	"read_by_default": false,
+	"entry_color": "8892c9",
 	"pages": [
 		{
 			"type": "text",
-			"text": "$(bold)\"$()$(italic)Humankind cannot gain anything without first giving something in return. To obtain, something of equal value must be lost. That is alchemy's first law of Equivalent Exchange.$(bold)\"$()$(br)...is what many authors would begin their textbooks with.$(br2)Fortunately for you, I am not \"many authors\"."
+			"text": "patchouli.gui.lexicon.index.info"
+		},
+		{
+			"type": "text",
+			"text": "advancements.nether.uneasy_alliance.description"
 		},
 		{
 			"type": "text",

--- a/src/main/resources/data/patchouli/patchouli_books/testbook2/en_us/entries/intro/smelttest.json
+++ b/src/main/resources/data/patchouli/patchouli_books/testbook2/en_us/entries/intro/smelttest.json
@@ -3,6 +3,7 @@
     "icon": "minecraft:furnace",
     "category": "intro",
     "priority": true,
+    "entry_color": "114fbf",
     "pages": [
         {
             "type": "doublerecipe",


### PR DESCRIPTION
* `i18n` toggle in book.json that makes every text renderer of the book try to translate the text.
* `i18n` variable function that attempts to translate the text sent.
* Custom entry colors for entries, defined in the same way as colors elsewhere.

I couldnt resist doing some minor cleanups where I touched stuff btw.