### PR TITLE
Don't ignore recipe linking for multiple stacks, allow tags in extra page mappings

### DIFF
--- a/src/main/java/vazkii/patchouli/client/book/BookEntry.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookEntry.java
@@ -15,7 +15,6 @@ import com.google.gson.annotations.SerializedName;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
-import vazkii.patchouli.api.PatchouliAPI;
 import vazkii.patchouli.client.base.ClientAdvancements;
 import vazkii.patchouli.client.base.PersistentData;
 import vazkii.patchouli.client.base.PersistentData.DataHolder.BookData;
@@ -205,13 +204,16 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 
 		if(extraRecipeMappings != null) {
 			for (Map.Entry<String, Integer> entry : extraRecipeMappings.entrySet()) {
-				ItemStack stack = ItemStackUtil.loadStackFromString(entry.getKey());
+				String key = entry.getKey();
+				List<ItemStack> stacks = ItemStackUtil.loadStackListFromString(key);
 				int pageNumber = entry.getValue();
-				if (!stack.isEmpty() && pageNumber < pages.length) {
-					addRelevantStack(stack, pageNumber);
+				if (!stacks.isEmpty() && pageNumber < pages.length) {
+					for (ItemStack stack : stacks) {
+						addRelevantStack(stack, pageNumber);
+					}
 				} else {
-					Patchouli.LOGGER.warn("Invalid extra recipe mapping: {} to page {} in entry {}", entry.getKey(), pageNumber, resource);
-				} 
+					Patchouli.LOGGER.warn("Invalid extra recipe mapping: {} to page {} in entry {}", key, pageNumber, resource);
+				}
 			}
 		}
 

--- a/src/main/java/vazkii/patchouli/client/book/template/component/ComponentItemStack.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/component/ComponentItemStack.java
@@ -28,8 +28,9 @@ public class ComponentItemStack extends TemplateComponent {
 	@Override
 	public void build(BookPage page, BookEntry entry, int pageNum) {
 		items = ItemStackUtil.loadStackListFromString(item);
-		if(linkedRecipe && items.size() == 1)
-			entry.addRelevantStack(items.get(0), pageNum);
+		if(linkedRecipe)
+			for (ItemStack stack : items)
+				entry.addRelevantStack(stack, pageNum);
 	}
 	
 	@Override

--- a/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
+++ b/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
@@ -102,9 +102,9 @@ public class ItemStackUtil {
 					for(Item item : tag.getAllElements())
 						stacks.add(new ItemStack(item));
 				}
+			} else {
+				stacks.add(loadStackFromString(stacksSerialized[i]));
 			}
-
-			stacks.add(loadStackFromString(stacksSerialized[i]));
 		}
 		return stacks;
 	}

--- a/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/intro/smelttest.json
+++ b/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/intro/smelttest.json
@@ -38,6 +38,7 @@
         "minecraft:dirt": 1,
         "minecraft:stone": 3,
         "minecraft:diamond_ore": 5,
+        "tag:minecraft:logs": 1,
         "minecraft:diamond": 888
     }
 }


### PR DESCRIPTION
Fixed a bug related to reading tags that didn't come up earlier in testing while at it - it will no longer interpret the tag as an item after adding its contents.