### PR TITLE
Remove deps from the generated pom for maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,11 @@ publishing {
             version project.version
             from components.java
             artifact srcJar
+            pom.withXml {
+                def node = asNode()
+                if(node.dependencies.size() > 0)
+                    node.remove(node.dependencies) // Remove deps, as they are all mappings-dependent and/or forge
+            }
         }
     }
 


### PR DESCRIPTION
`{ transitive = false }` is ugly and gets weird questions from people not knowing what's happening when their dev env tries to pull a different Forge version.