### PR TITLE
Random fixes related to book icons and book parsing

### DIFF
--- a/src/main/java/vazkii/patchouli/client/book/BookCategory.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookCategory.java
@@ -40,7 +40,7 @@ public class BookCategory extends AbstractReadStateHolder implements Comparable<
 
 	public BookIcon getIcon() {
 		if(icon == null)
-			icon = new BookIcon(iconRaw);
+			icon = BookIcon.from(iconRaw);
 
 		return icon;
 	}

--- a/src/main/java/vazkii/patchouli/client/book/BookContents.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookContents.java
@@ -120,7 +120,7 @@ public class BookContents extends AbstractReadStateHolder {
 			
 			if(book.indexIconRaw == null || book.indexIconRaw.isEmpty())
 				indexIcon = new BookIcon(book.getBookItem());
-			else indexIcon = new BookIcon(book.indexIconRaw);
+			else indexIcon = BookIcon.from(book.indexIconRaw);
 		}
 
 		List<ResourceLocation> foundCategories = new ArrayList<>();

--- a/src/main/java/vazkii/patchouli/client/book/BookEntry.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookEntry.java
@@ -87,7 +87,7 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 
 	public BookIcon getIcon() {
 		if(icon == null)
-			icon = new BookIcon(iconRaw); 
+			icon = BookIcon.from(iconRaw);
 
 		return icon;
 	}
@@ -205,14 +205,20 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 		if(extraRecipeMappings != null) {
 			for (Map.Entry<String, Integer> entry : extraRecipeMappings.entrySet()) {
 				String key = entry.getKey();
-				List<ItemStack> stacks = ItemStackUtil.loadStackListFromString(key);
+				List<ItemStack> stacks;
 				int pageNumber = entry.getValue();
+				try {
+					stacks = ItemStackUtil.loadStackListFromString(key);
+				} catch (Exception e) {
+					Patchouli.LOGGER.warn("Invalid extra recipe mapping: {} to page {} in entry {}: {}", key, pageNumber, resource, e.getMessage());
+					continue;
+				}
 				if (!stacks.isEmpty() && pageNumber < pages.length) {
 					for (ItemStack stack : stacks) {
 						addRelevantStack(stack, pageNumber);
 					}
 				} else {
-					Patchouli.LOGGER.warn("Invalid extra recipe mapping: {} to page {} in entry {}", key, pageNumber, resource);
+					Patchouli.LOGGER.warn("Invalid extra recipe mapping: {} to page {} in entry {}: Empty entry or page out of bounds", key, pageNumber, resource);
 				}
 			}
 		}

--- a/src/main/java/vazkii/patchouli/client/book/BookEntry.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookEntry.java
@@ -142,7 +142,7 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 	}
 
 	public boolean canAdd() {
-		return (flag == null || flag.isEmpty() || PatchouliConfig.getConfigFlag(flag)) && getCategory() != null;
+		return (flag == null || flag.isEmpty() || PatchouliConfig.getConfigFlag(flag));
 	}
 
 	public boolean isFoundByQuery(String query) {

--- a/src/main/java/vazkii/patchouli/client/book/BookIcon.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookIcon.java
@@ -50,7 +50,7 @@ public class BookIcon {
 		case RESOURCE:
 			GlStateManager.color4f(1F, 1F, 1F, 1F);
 			mc.textureManager.bindTexture(res);
-			AbstractGui.blit(x, y, 0, 0, 16, 16, 16, 16, 16, 16);
+			AbstractGui.blit(x, y, 0, 0, 16, 16, 16, 16);
 			break;
 		}
 	}

--- a/src/main/java/vazkii/patchouli/client/book/BookIcon.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookIcon.java
@@ -7,46 +7,50 @@ import net.minecraft.client.gui.AbstractGui;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import vazkii.patchouli.common.base.Patchouli;
 import vazkii.patchouli.common.util.ItemStackUtil;
 
 public class BookIcon {
+	private static final BookIcon EMPTY = new BookIcon(ItemStack.EMPTY);
 
 	private final IconType type;
 	private final ItemStack stack;
 	private final ResourceLocation res;
-	
-	public BookIcon(String str) {
+
+	public static BookIcon from(String str) {
 		if(str.endsWith(".png")) {
-			type = IconType.RESOURCE;
-			stack = null;
-			res = new ResourceLocation(str);
+			return new BookIcon(new ResourceLocation(str));
 		} else {
-			type = IconType.STACK;
-			stack = ItemStackUtil.loadStackFromString(str);
-			res = null;
+			try {
+				ItemStack stack = ItemStackUtil.loadStackFromString(str);
+				return new BookIcon(stack);
+			} catch (Exception e) {
+				Patchouli.LOGGER.warn("Invalid icon item stack: {}", e.getMessage());
+				return EMPTY;
+			}
 		}
 	}
-	
+
 	public BookIcon(ItemStack stack) {
 		type = IconType.STACK;
 		this.stack = stack;
 		res = null;
 	}
-	
+
 	public BookIcon(ResourceLocation res) {
 		type = IconType.RESOURCE;
 		stack = null;
 		this.res = res;
 	}
-	
+
 	public void render(int x, int y) {
 		Minecraft mc = Minecraft.getInstance();
 		switch(type) {
 		case STACK:
 			RenderHelper.enableGUIStandardItemLighting();
-			mc.getItemRenderer().renderItemIntoGUI(stack, x, y);	
+			mc.getItemRenderer().renderItemIntoGUI(stack, x, y);
 			break;
-			
+
 		case RESOURCE:
 			GlStateManager.color4f(1F, 1F, 1F, 1F);
 			mc.textureManager.bindTexture(res);
@@ -54,9 +58,9 @@ public class BookIcon {
 			break;
 		}
 	}
-	
+
 	private enum IconType {
 		STACK, RESOURCE
 	}
-	
+
 }


### PR DESCRIPTION
* Fix book icon rendering for resource-based icons - they no longer display as blank.
* Fix invalid categories not being logged - before the category was checked to print the error message, it was checked to see if the entry can be added in the first place, so it never printed the message.
* Fix #170 and some other instances of wrong items crashing or stopping the book from fully loading. All errors should be logged now.