### PR TITLE
Add JEI plugin to allow displaying all book types in JEI panel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,9 +56,17 @@ minecraft {
         }
     }
 }
+repositories {
+    maven {
+        url = "https://dvs1.progwml6.com/files/maven/"
+    }
+}
 
 dependencies {
     minecraft "net.minecraftforge:forge:${config.mc_version}-${config.forge_version}"
+
+    compileOnly fg.deobf("mezz.jei:jei-${config.mc_version}:${config.jei_version}:api")
+    runtimeOnly fg.deobf("mezz.jei:jei-${config.mc_version}:${config.jei_version}")
 }
 
 processResources {

--- a/build.properties
+++ b/build.properties
@@ -8,4 +8,5 @@ mod_id=patchouli
 version=1.1
 dir_output=../Build Output/Patchouli/
 mc_version=1.14.4
+jei_version=6.0.0.26
 build_number=23

--- a/src/main/java/vazkii/patchouli/client/jei/PatchouliJeiPlugin.java
+++ b/src/main/java/vazkii/patchouli/client/jei/PatchouliJeiPlugin.java
@@ -1,0 +1,31 @@
+package vazkii.patchouli.client.jei;
+
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.registration.ISubtypeRegistration;
+import net.minecraft.util.ResourceLocation;
+import vazkii.patchouli.common.base.Patchouli;
+import vazkii.patchouli.common.item.ItemModBook;
+import vazkii.patchouli.common.item.PatchouliItems;
+
+import javax.annotation.Nonnull;
+
+@JeiPlugin
+public class PatchouliJeiPlugin implements IModPlugin {
+	private static final ResourceLocation UID = new ResourceLocation(Patchouli.MOD_ID, Patchouli.MOD_ID);
+
+	@Nonnull
+	@Override
+	public ResourceLocation getPluginUid() {
+		return UID;
+	}
+
+	@Override
+	public void registerItemSubtypes(ISubtypeRegistration registration) {
+		registration.registerSubtypeInterpreter(PatchouliItems.book, stack -> {
+			if (!stack.hasTag() || !stack.getTag().contains(ItemModBook.TAG_BOOK))
+				return "";
+			return stack.getTag().getString(ItemModBook.TAG_BOOK);
+		});
+	}
+}

--- a/src/main/java/vazkii/patchouli/common/item/ItemModBook.java
+++ b/src/main/java/vazkii/patchouli/common/item/ItemModBook.java
@@ -37,7 +37,7 @@ import vazkii.patchouli.common.network.message.MessageOpenBookGui;
 
 public class ItemModBook extends Item {
 
-	private static final String TAG_BOOK = "patchouli:book";
+	public static final String TAG_BOOK = "patchouli:book";
 
 	public ItemModBook() {
 		super(new Item.Properties()


### PR DESCRIPTION
Same thing as with Botania and Quark - JEI for 1.14 ignores NBT subtypes by default and only displays the first item.