### PR TITLE
Allow for multiblocks to use Tags

### DIFF
--- a/src/main/java/vazkii/patchouli/common/multiblock/DenseMultiblock.java
+++ b/src/main/java/vazkii/patchouli/common/multiblock/DenseMultiblock.java
@@ -1,5 +1,6 @@
 package vazkii.patchouli.common.multiblock;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -73,6 +74,12 @@ public class DenseMultiblock extends AbstractMultiblock {
 				state = StateMatcher.fromBlockLoose((Block) o);
 			else if(o instanceof BlockState)
 				state = StateMatcher.fromState((BlockState) o);
+			else if(o instanceof String)
+				try {
+					state = StringStateMatcher.fromString((String) o);
+				} catch (CommandSyntaxException e) {
+					throw new RuntimeException(e);
+				}
 			else if(o instanceof IStateMatcher)
 				state = (IStateMatcher) o;
 			else throw new IllegalArgumentException("Invalid target " + o);


### PR DESCRIPTION
This PR just adds the ability to use Block Tags in Multiblocks without needing to make your own StateMatcher.