### PR TITLE
Add macro $(iname:<itemstackstring>) to display item names

### DIFF
--- a/src/main/java/vazkii/patchouli/client/book/text/BookTextParser.java
+++ b/src/main/java/vazkii/patchouli/client/book/text/BookTextParser.java
@@ -10,6 +10,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextFormatting;
 import vazkii.patchouli.client.book.BookEntry;
@@ -18,6 +19,7 @@ import vazkii.patchouli.client.book.gui.GuiBookEntry;
 import vazkii.patchouli.client.handler.UnicodeFontHandler;
 import vazkii.patchouli.common.base.Patchouli;
 import vazkii.patchouli.common.book.Book;
+import vazkii.patchouli.common.util.ItemStackUtil;
 
 import javax.annotation.Nullable;
 
@@ -153,6 +155,10 @@ public class BookTextParser {
 			state.onClick = null;
 			return "";
 		}, "/c");
+		register((parameter, state) -> {
+			ItemStack stack = ItemStackUtil.loadStackFromString(parameter);
+			return stack.getDisplayName().getFormattedText();
+		}, "iname");
 	}
 
 	private final GuiBook gui;

--- a/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/test/iname_macro.json
+++ b/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/test/iname_macro.json
@@ -1,0 +1,13 @@
+{
+	"name": "iname macro test",
+	"icon": "minecraft:dirt",
+	"category": "test",
+	"priority": true,
+	"read_by_default": false,
+	"pages": [
+		{
+			"type": "text",
+			"text": "This is a test entry with an item name macro: $(iname:minecraft:dirt)"
+		}
+	]
+}


### PR DESCRIPTION
Adds a macro $(iname:<param>) to BookTextParser to display item names based on an ItemStack string, thus translating `"text": "This is a test entry with an item name macro: $(iname:minecraft:dirt)"` to ![image](https://user-images.githubusercontent.com/60774993/76678099-63801800-65d5-11ea-8493-274b8d54ce76.png).

A test entry for testbook1 is included.
