### PR TITLE
pull method getSize from AbstractMultiblock to IMultiblock

### DIFF
--- a/src/main/java/vazkii/patchouli/api/IMultiblock.java
+++ b/src/main/java/vazkii/patchouli/api/IMultiblock.java
@@ -5,6 +5,7 @@ import com.mojang.datafixers.util.Pair;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
@@ -108,6 +109,13 @@ public interface IMultiblock {
 	 * @param start The anchor position. The multiblock's {@link #offset} is not applied to this.
 	 */
 	boolean test(World world, BlockPos start, int x, int y, int z, Rotation rotation);
+
+	/**
+	 * Gets the size of this multiblock
+	 *
+	 * @return The size of the multiblock
+	 */
+	Vec3i getSize();
 
 	interface SimulateResult {
 		/**

--- a/src/main/java/vazkii/patchouli/api/stub/StubMultiblock.java
+++ b/src/main/java/vazkii/patchouli/api/stub/StubMultiblock.java
@@ -5,6 +5,7 @@ import com.mojang.datafixers.util.Pair;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.World;
 
 import vazkii.patchouli.api.IMultiblock;
@@ -71,6 +72,11 @@ public class StubMultiblock implements IMultiblock {
 	@Override
 	public boolean test(World world, BlockPos start, int x, int y, int z, Rotation rotation) {
 		return false;
+	}
+
+	@Override
+	public Vec3i getSize() {
+		return Vec3i.NULL_VECTOR;
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/common/multiblock/AbstractMultiblock.java
+++ b/src/main/java/vazkii/patchouli/common/multiblock/AbstractMultiblock.java
@@ -169,5 +169,4 @@ public abstract class AbstractMultiblock implements IMultiblock, ILightReader {
 		return 15 - ambientDarkening;
 	}
 
-	public abstract Vec3i getSize();
 }


### PR DESCRIPTION
I think it makes sense to have the getSize method in IMultiblock and visible for API users instead of AbstractMultiblock (which is not visible for API users)