### PR TITLE
Add book rendering crash report diagnostics

### DIFF
--- a/src/main/java/vazkii/patchouli/client/base/ClientProxy.java
+++ b/src/main/java/vazkii/patchouli/client/base/ClientProxy.java
@@ -1,13 +1,13 @@
 package vazkii.patchouli.client.base;
 
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.CrashReportExtender;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 import vazkii.patchouli.client.book.ClientBookRegistry;
+import vazkii.patchouli.client.handler.BookCrashHandler;
 import vazkii.patchouli.common.base.CommonProxy;
-import vazkii.patchouli.common.book.BookRegistry;
 
 public class ClientProxy extends CommonProxy {
 
@@ -22,6 +22,7 @@ public class ClientProxy extends CommonProxy {
 	public void setupClient(FMLClientSetupEvent event) {
 		ClientBookRegistry.INSTANCE.init();
 		PersistentData.setup();
+		CrashReportExtender.registerCrashCallable(new BookCrashHandler());
 	}
 
 	@Override

--- a/src/main/java/vazkii/patchouli/client/book/gui/GuiBookEntryList.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/GuiBookEntryList.java
@@ -216,4 +216,8 @@ public abstract class GuiBookEntryList extends GuiBook {
 		}
 	}
 
+	public String getSearchQuery() {
+		return searchField.getText();
+	}
+
 }

--- a/src/main/java/vazkii/patchouli/client/handler/BookCrashHandler.java
+++ b/src/main/java/vazkii/patchouli/client/handler/BookCrashHandler.java
@@ -1,0 +1,52 @@
+package vazkii.patchouli.client.handler;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraftforge.fml.common.ICrashCallable;
+
+import vazkii.patchouli.client.book.gui.GuiBook;
+import vazkii.patchouli.client.book.gui.GuiBookEntry;
+import vazkii.patchouli.client.book.gui.GuiBookEntryList;
+import vazkii.patchouli.common.book.Book;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class BookCrashHandler implements ICrashCallable {
+	private static final String INDENT = "\n\t\t";
+
+	@Override
+	public String getLabel() {
+		return "Patchouli open book context";
+	}
+
+	@Override
+	public String call() {
+		Screen screen = Minecraft.getInstance().currentScreen;
+		if (!(screen instanceof GuiBook)) {
+			return "n/a";
+		}
+		GuiBook gui = (GuiBook) screen;
+		Book book = gui.book;
+		StringBuilder builder = new StringBuilder(INDENT);
+
+		builder.append("Open book: ").append(book.id);
+		if (gui instanceof GuiBookEntry) {
+			builder.append(INDENT).append("Current entry: ").append(((GuiBookEntry) gui).getEntry().getId());
+		} else if (gui instanceof GuiBookEntryList) {
+			builder.append(INDENT).append("Search query: ").append(((GuiBookEntryList) gui).getSearchQuery());
+		}
+		builder.append(INDENT).append("Current page spread: ").append(gui.getSpread());
+		if (book.contents.isErrored()) {
+			Exception ex = book.contents.getException();
+			builder.append(INDENT).append("Book loading error: ");
+			try (StringWriter sw = new StringWriter();
+					PrintWriter pw = new PrintWriter(sw)) {
+				ex.printStackTrace(pw);
+				builder.append(sw.toString().replaceAll("\n", INDENT));
+			} catch (IOException ignored) {}
+		}
+		return builder.toString();
+	}
+}


### PR DESCRIPTION
Adds a printout to the crash report with info about: current book open, current page and page number (or search query for search pages), and the loading exception stack trace. This data is only present if the current gui open is a book.