### PR TITLE
[Improvement] Image component integer json properties now accept variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ Thumbs.db
 ## ForgeGradle
 /run
 
+##vscode
+/.vscode
+
 ## eclipse
 /.settings
 /.metadata

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/vazkii/patchouli/client/book/template/component/ComponentImage.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/component/ComponentImage.java
@@ -18,10 +18,16 @@ public class ComponentImage extends TemplateComponent {
 
 	public String image;
 
-	public int u, v, width, height;
+	@SerializedName("u") public IVariable u;
+	@SerializedName("v") public IVariable v;
+	@SerializedName("width") public IVariable width;
+	@SerializedName("height") public IVariable height;
 
-	@SerializedName("texture_width") public int textureWidth = 256;
-	@SerializedName("texture_height") public int textureHeight = 256;
+	@SerializedName("texture_width") public IVariable textureWidth;
+	@SerializedName("texture_height") public IVariable textureHeight;
+
+	public int tWidth;
+	public int tHeight;
 
 	public float scale = 1F;
 
@@ -29,6 +35,18 @@ public class ComponentImage extends TemplateComponent {
 
 	@Override
 	public void build(BookPage page, BookEntry entry, int pageNum) {
+		try {
+			tWidth = textureWidth.asNumber().intValue();
+		} catch (NumberFormatException e) {
+			tWidth = 256;
+		}
+
+		try {
+			tHeight = textureHeight.asNumber().intValue();
+		} catch (NumberFormatException e) {
+			tHeight = 256;
+		}
+
 		if (image.contains(":")) {
 			resource = new Identifier(image);
 		} else {
@@ -40,6 +58,12 @@ public class ComponentImage extends TemplateComponent {
 	public void onVariablesAvailable(UnaryOperator<IVariable> lookup) {
 		super.onVariablesAvailable(lookup);
 		image = lookup.apply(IVariable.wrap(image)).asString();
+		u = lookup.apply(u);
+		v = lookup.apply(u);
+		width = lookup.apply(width);
+		height = lookup.apply(height);
+		textureWidth = lookup.apply(width);
+		textureHeight = lookup.apply(height);
 	}
 
 	@Override
@@ -54,7 +78,7 @@ public class ComponentImage extends TemplateComponent {
 		ms.scale(scale, scale, scale);
 		RenderSystem.color4f(1F, 1F, 1F, 1F);
 		RenderSystem.enableBlend();
-		DrawableHelper.drawTexture(ms, 0, 0, u, v, width, height, textureWidth, textureHeight);
+		DrawableHelper.drawTexture(ms, 0, 0, u.asNumber().floatValue(), v.asNumber().floatValue(), width.asNumber().intValue(), height.asNumber().intValue(), tWidth, tHeight);
 		ms.pop();
 	}
 

--- a/src/main/java/vazkii/patchouli/client/book/template/component/ComponentImage.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/component/ComponentImage.java
@@ -26,8 +26,7 @@ public class ComponentImage extends TemplateComponent {
 	@SerializedName("texture_width") public IVariable textureWidth;
 	@SerializedName("texture_height") public IVariable textureHeight;
 
-	public int tWidth;
-	public int tHeight;
+	public int uInt,vInt,widthInt,heightInt,textureWidthInt,textureHeightInt;
 
 	public float scale = 1F;
 
@@ -35,18 +34,6 @@ public class ComponentImage extends TemplateComponent {
 
 	@Override
 	public void build(BookPage page, BookEntry entry, int pageNum) {
-		try {
-			tWidth = textureWidth.asNumber().intValue();
-		} catch (NumberFormatException e) {
-			tWidth = 256;
-		}
-
-		try {
-			tHeight = textureHeight.asNumber().intValue();
-		} catch (NumberFormatException e) {
-			tHeight = 256;
-		}
-
 		if (image.contains(":")) {
 			resource = new Identifier(image);
 		} else {
@@ -62,8 +49,8 @@ public class ComponentImage extends TemplateComponent {
 		v = lookup.apply(u);
 		width = lookup.apply(width);
 		height = lookup.apply(height);
-		textureWidth = lookup.apply(width);
-		textureHeight = lookup.apply(height);
+		textureWidth = lookup.apply(textureWidth);
+		textureHeight = lookup.apply(textureHeight);
 	}
 
 	@Override
@@ -72,14 +59,55 @@ public class ComponentImage extends TemplateComponent {
 			return;
 		}
 
+		checkValues();
+
 		page.mc.getTextureManager().bindTexture(resource);
 		ms.push();
 		ms.translate(x, y, 0);
 		ms.scale(scale, scale, scale);
 		RenderSystem.color4f(1F, 1F, 1F, 1F);
 		RenderSystem.enableBlend();
-		DrawableHelper.drawTexture(ms, 0, 0, u.asNumber().floatValue(), v.asNumber().floatValue(), width.asNumber().intValue(), height.asNumber().intValue(), tWidth, tHeight);
+		DrawableHelper.drawTexture(ms, 0, 0, uInt,vInt,widthInt,heightInt,textureWidthInt,textureHeightInt);
 		ms.pop();
+	}
+
+	//prepares all the Ivariables and defaults them if they are of improper type
+	private void checkValues(){
+		try {
+			textureWidthInt = textureWidth.asNumber().intValue();
+		} catch (Exception e) {
+			textureWidthInt = 256;
+		}
+
+		try {
+			textureHeightInt = textureHeight.asNumber().intValue();
+		} catch (Exception e) {
+			textureHeightInt = 256;
+		}
+
+		try {
+			uInt = u.asNumber().intValue();
+		} catch (Exception e) {
+			uInt = 0;
+		}
+
+		try {
+			vInt = v.asNumber().intValue();
+		} catch (Exception e) {
+			vInt = 0;
+		}
+
+		try {
+			widthInt = width.asNumber().intValue();
+		} catch (Exception e) {
+			widthInt = 0;
+		}
+
+		try {
+			heightInt = height.asNumber().intValue();
+		} catch (Exception e) {
+			heightInt = 0;
+		}
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/client/book/template/component/ComponentImage.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/component/ComponentImage.java
@@ -26,7 +26,7 @@ public class ComponentImage extends TemplateComponent {
 	@SerializedName("texture_width") public IVariable textureWidth;
 	@SerializedName("texture_height") public IVariable textureHeight;
 
-	public int uInt,vInt,widthInt,heightInt,textureWidthInt,textureHeightInt;
+	public int uInt, vInt, widthInt, heightInt, textureWidthInt, textureHeightInt;
 
 	public float scale = 1F;
 
@@ -67,12 +67,12 @@ public class ComponentImage extends TemplateComponent {
 		ms.scale(scale, scale, scale);
 		RenderSystem.color4f(1F, 1F, 1F, 1F);
 		RenderSystem.enableBlend();
-		DrawableHelper.drawTexture(ms, 0, 0, uInt,vInt,widthInt,heightInt,textureWidthInt,textureHeightInt);
+		DrawableHelper.drawTexture(ms, 0, 0, uInt, vInt, widthInt, heightInt, textureWidthInt, textureHeightInt);
 		ms.pop();
 	}
 
 	//prepares all the Ivariables and defaults them if they are of improper type
-	private void checkValues(){
+	private void checkValues() {
 		try {
 			textureWidthInt = textureWidth.asNumber().intValue();
 		} catch (Exception e) {


### PR DESCRIPTION
I converted the int variables (width, height, ect.) in the image component to ivariables so that this works:
```
{
    "components":[
        {
            "type": "image",
            "image": "image.png",
            "u": "#u_value",
            "v": "#v_value",
            "width": "#width_value",
           ....
        }
    ]
}
```
```
{
	"name": "name",
	"category": "category",
	"sortnum": 0,
	"pages": [
		{
			"type":"template",
			"u_value":"18",
			"v_value":"17",
                        ...
		}
	]
}
```
If the pull request is accepted, ill do this for the other components (i didnt want to go ahead before making sure the changes were wanted)

Also, i updated the gradle version in the gradle-wrapper properties because the old version didn't work with jdk 14