### PR TITLE
Fix negation of missing config flags

### DIFF
--- a/src/main/java/vazkii/patchouli/common/base/PatchouliConfig.java
+++ b/src/main/java/vazkii/patchouli/common/base/PatchouliConfig.java
@@ -85,11 +85,12 @@ public class PatchouliConfig {
 
 		Boolean b = CONFIG_FLAGS.get(name);
 		if (b == null) {
-			Patchouli.LOGGER.warn("Queried for unknown config flag: {}", name);
-			return false;
-		} else {
-			return b == target;
+			if (!name.startsWith("mod:")) {
+				Patchouli.LOGGER.warn("Queried for unknown config flag: {}", name);
+			}
+			b = false;
 		}
+		return b == target;
 	}
 
 	public static boolean getConfigFlagAND(String[] tokens) {

--- a/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/categories/config_flags.json
+++ b/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/categories/config_flags.json
@@ -1,0 +1,5 @@
+{
+  "name": "Config Flag Test",
+  "description": "Test pages for config flags and their usage",
+  "icon": "minecraft:comparator"
+}

--- a/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/config_flags/appears_gog_missing.json
+++ b/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/config_flags/appears_gog_missing.json
@@ -1,0 +1,12 @@
+{
+  "name": "Appears if GoG is missing",
+  "category": "config_flags",
+  "flag": "!mod:gardenofglass",
+  "icon": "minecraft:oak_sapling",
+  "pages": [
+    {
+      "type": "text",
+      "text": "If this page doesn't appear, Botania will be sad because Orechid won't appear in its lexicon either."
+    }
+  ]
+}


### PR DESCRIPTION
This was a problem since forever, and it turns out an undefined config flag would just discard everything and return false.

Closes Vazkii/Botania#3450