### PR TITLE
Refactor BookContents to be correct-by-construction

### DIFF
--- a/src/main/java/vazkii/patchouli/client/book/BookContentClasspathLoader.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookContentClasspathLoader.java
@@ -1,0 +1,63 @@
+package vazkii.patchouli.client.book;
+
+import net.fabricmc.loader.api.ModContainer;
+import net.minecraft.util.Identifier;
+
+import org.apache.commons.io.FilenameUtils;
+import org.jetbrains.annotations.Nullable;
+
+import vazkii.patchouli.common.base.Patchouli;
+import vazkii.patchouli.common.book.Book;
+import vazkii.patchouli.common.book.BookRegistry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.BiFunction;
+
+public final class BookContentClasspathLoader implements BookContentLoader {
+	public static final BookContentClasspathLoader INSTANCE = new BookContentClasspathLoader();
+
+	private BookContentClasspathLoader() {}
+
+	private BiFunction<Path, Path, Boolean> pred(String modId, List<Identifier> list) {
+		return (root, file) -> {
+			Path rel = root.relativize(file);
+			String relName = rel.toString();
+			if (relName.endsWith(".json")) {
+				relName = FilenameUtils.removeExtension(FilenameUtils.separatorsToUnix(relName));
+				Identifier res = new Identifier(modId, relName);
+				list.add(res);
+			}
+
+			return true;
+		};
+	}
+
+	@Override
+	public void findFiles(Book book, String dir, List<Identifier> list) {
+		ModContainer mod = book.owner;
+		String id = mod.getMetadata().getId();
+		BookRegistry.findFiles(mod, String.format("data/%s/%s/%s/%s/%s", id, BookRegistry.BOOKS_LOCATION, book.id.getPath(), BookContentsBuilder.DEFAULT_LANG, dir), path -> true, pred(id, list), false);
+	}
+
+	@Nullable
+	@Override
+	public InputStream loadJson(Book book, Identifier resloc, @Nullable Identifier fallback) {
+		String path = "data/" + resloc.getNamespace() + "/" + resloc.getPath();
+		Patchouli.LOGGER.debug("Loading {}", path);
+
+		try {
+			return Files.newInputStream(book.owner.getPath(path));
+		} catch (IOException ex) {
+			if (fallback != null) {
+				Patchouli.LOGGER.warn("Failed to load " + resloc + ". Switching to fallback.");
+				return loadJson(book, fallback, null);
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/vazkii/patchouli/client/book/BookContentExternalLoader.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookContentExternalLoader.java
@@ -14,16 +14,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-public class ExternalBookContents extends BookContents {
+public final class BookContentExternalLoader implements BookContentLoader {
+	public static final BookContentExternalLoader INSTANCE = new BookContentExternalLoader();
 
-	public ExternalBookContents(Book book) {
-		super(book);
-	}
+	private BookContentExternalLoader() {}
 
 	@Override
-	protected void findFiles(String dir, List<Identifier> list) {
+	public void findFiles(Book book, String dir, List<Identifier> list) {
 		File root = new File(BookFolderLoader.loadDir, book.id.getPath());
-		File enUs = new File(root, DEFAULT_LANG);
+		File enUs = new File(root, BookContentsBuilder.DEFAULT_LANG);
 		if (enUs.exists()) {
 			File searchDir = new File(enUs, dir);
 			if (searchDir.exists()) {
@@ -52,7 +51,7 @@ public class ExternalBookContents extends BookContents {
 	}
 
 	@Override
-	protected InputStream loadJson(Identifier resloc, Identifier fallback) {
+	public InputStream loadJson(Book book, Identifier resloc, Identifier fallback) {
 		String realPath = resloc.getPath().substring(BookFolderLoader.loadDir.getName().length());
 		File targetFile = new File(BookFolderLoader.loadDir, realPath);
 
@@ -68,7 +67,7 @@ public class ExternalBookContents extends BookContents {
 
 		if (fallback != null) {
 			Patchouli.LOGGER.warn("Failed to load " + resloc + ". Switching to fallback.");
-			return loadJson(fallback, null);
+			return loadJson(book, fallback, null);
 		}
 
 		return null;

--- a/src/main/java/vazkii/patchouli/client/book/BookContentLoader.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookContentLoader.java
@@ -1,0 +1,17 @@
+package vazkii.patchouli.client.book;
+
+import net.minecraft.util.Identifier;
+
+import vazkii.patchouli.common.book.Book;
+
+import javax.annotation.Nullable;
+
+import java.io.InputStream;
+import java.util.List;
+
+public interface BookContentLoader {
+	void findFiles(Book book, String dir, List<Identifier> list);
+
+	@Nullable
+	InputStream loadJson(Book book, Identifier resloc, @Nullable Identifier fallback);
+}

--- a/src/main/java/vazkii/patchouli/client/book/BookContents.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookContents.java
@@ -1,63 +1,73 @@
 package vazkii.patchouli.client.book;
 
+import com.google.common.collect.ImmutableMap;
 import com.mojang.datafixers.util.Pair;
 
-import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
-
-import org.apache.commons.io.FilenameUtils;
 
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
 import vazkii.patchouli.client.book.gui.GuiBookLanding;
 import vazkii.patchouli.client.book.template.BookTemplate;
-import vazkii.patchouli.common.base.Patchouli;
 import vazkii.patchouli.common.book.Book;
-import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.util.ItemStackUtil;
 import vazkii.patchouli.common.util.ItemStackUtil.StackWrapper;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import javax.annotation.Nullable;
+
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class BookContents extends AbstractReadStateHolder {
 
-	protected static final String DEFAULT_LANG = "en_us";
-
 	public static final Map<Identifier, Supplier<BookTemplate>> addonTemplates = new ConcurrentHashMap<>();
 
-	public final Book book;
+	private final Book book;
 
-	public Map<Identifier, BookCategory> categories = new HashMap<>();
-	public Map<Identifier, BookEntry> entries = new HashMap<>();
-	public Map<Identifier, Supplier<BookTemplate>> templates = new HashMap<>();
-	public Map<StackWrapper, Pair<BookEntry, Integer>> recipeMappings = new HashMap<>();
-	private boolean errored = false;
-	private Exception exception = null;
+	public final Map<Identifier, BookCategory> categories;
+	public final Map<Identifier, BookEntry> entries;
+	public final Map<Identifier, Supplier<BookTemplate>> templates;
+	public final Map<StackWrapper, Pair<BookEntry, Integer>> recipeMappings = new HashMap<>();
+	private final boolean errored;
+	@Nullable private final Exception exception;
 
-	public Deque<GuiBook> guiStack = new ArrayDeque<>();
-	public GuiBook currentGui;
+	public final Deque<GuiBook> guiStack = new ArrayDeque<>();
+	public GuiBook currentGui = null;
 
-	public BookIcon indexIcon;
-
-	public BookContents(Book book) {
+	private BookContents(Book book, @Nullable Exception e) {
 		this.book = book;
+		this.errored = e != null;
+		this.exception = e;
+		this.categories = Collections.emptyMap();
+		this.entries = Collections.emptyMap();
+		this.templates = Collections.emptyMap();
+	}
+
+	public static BookContents empty(Book book, @Nullable Exception e) {
+		return new BookContents(book, e);
+	}
+
+	public BookContents(Book book,
+			ImmutableMap<Identifier, BookCategory> categories,
+			ImmutableMap<Identifier, BookEntry> entries,
+			ImmutableMap<Identifier, Supplier<BookTemplate>> templates) {
+		this.book = book;
+		this.categories = categories;
+		this.entries = entries;
+		this.templates = templates;
+		this.errored = false;
+		this.exception = null;
 	}
 
 	public boolean isErrored() {
 		return errored;
 	}
 
+	@Nullable
 	public Exception getException() {
 		return exception;
 	}
@@ -84,178 +94,6 @@ public class BookContents extends AbstractReadStateHolder {
 			mc.openScreen(gui);
 			gui.onFirstOpened();
 		}
-	}
-
-	public void reload(boolean isOverride) {
-		errored = false;
-
-		if (!isOverride) {
-			currentGui = null;
-			guiStack.clear();
-			categories.clear();
-			entries.clear();
-			templates.clear();
-			recipeMappings.clear();
-
-			templates.putAll(addonTemplates);
-
-			if (book.indexIconRaw == null || book.indexIconRaw.isEmpty()) {
-				indexIcon = new BookIcon(book.getBookItem());
-			} else {
-				indexIcon = BookIcon.from(book.indexIconRaw);
-			}
-		}
-
-		List<Identifier> foundCategories = new ArrayList<>();
-		List<Identifier> foundEntries = new ArrayList<>();
-		List<Identifier> foundTemplates = new ArrayList<>();
-
-		try {
-			String bookName = book.id.getPath();
-
-			findFiles("categories", foundCategories);
-			findFiles("entries", foundEntries);
-			findFiles("templates", foundTemplates);
-
-			foundCategories.forEach(c -> loadCategory(c, new Identifier(c.getNamespace(),
-					String.format("%s/%s/%s/categories/%s.json", BookRegistry.BOOKS_LOCATION, bookName, DEFAULT_LANG, c.getPath())), book));
-			foundEntries.stream().map(id -> loadEntry(id, new Identifier(id.getNamespace(),
-					String.format("%s/%s/%s/entries/%s.json", BookRegistry.BOOKS_LOCATION, bookName, DEFAULT_LANG, id.getPath())), book))
-					.filter(Optional::isPresent)
-					.map(Optional::get)
-					.forEach(b -> entries.put(b.getId(), b));
-			foundTemplates.forEach(e -> loadTemplate(e, new Identifier(e.getNamespace(),
-					String.format("%s/%s/%s/templates/%s.json", BookRegistry.BOOKS_LOCATION, bookName, DEFAULT_LANG, e.getPath()))));
-
-			categories.forEach((id, category) -> {
-				try {
-					category.build(id);
-				} catch (Exception e) {
-					throw new RuntimeException("Error while building category " + id, e);
-				}
-			});
-
-			entries.values().forEach(entry -> {
-				try {
-					entry.build();
-				} catch (Exception e) {
-					throw new RuntimeException("Error building entry " + entry.getId(), e);
-				}
-			});
-		} catch (Exception e) {
-			exception = e;
-			errored = true;
-			Patchouli.LOGGER.error("Error while loading contents for book {}", book.id, e);
-		}
-	}
-
-	protected void findFiles(String dir, List<Identifier> list) {
-		ModContainer mod = book.owner;
-		String id = mod.getMetadata().getId();
-		BookRegistry.findFiles(mod, String.format("data/%s/%s/%s/%s/%s", id, BookRegistry.BOOKS_LOCATION, book.id.getPath(), DEFAULT_LANG, dir), path -> true, pred(id, list), false);
-	}
-
-	private BiFunction<Path, Path, Boolean> pred(String modId, List<Identifier> list) {
-		return (root, file) -> {
-			Path rel = root.relativize(file);
-			String relName = rel.toString();
-			if (relName.endsWith(".json")) {
-				relName = FilenameUtils.removeExtension(FilenameUtils.separatorsToUnix(relName));
-				Identifier res = new Identifier(modId, relName);
-				list.add(res);
-			}
-
-			return true;
-		};
-	}
-
-	private void loadCategory(Identifier key, Identifier res, Book book) {
-		try (Reader stream = loadLocalizedJson(res)) {
-			BookCategory category = ClientBookRegistry.INSTANCE.gson.fromJson(stream, BookCategory.class);
-			if (category == null) {
-				throw new IllegalArgumentException(res + " does not exist.");
-			}
-
-			category.setBook(book);
-			if (category.canAdd()) {
-				categories.put(key, category);
-			}
-		} catch (IOException ex) {
-			throw new UncheckedIOException(ex);
-		}
-	}
-
-	private Optional<BookEntry> loadEntry(Identifier id, Identifier file, Book book) {
-		try (Reader stream = loadLocalizedJson(file)) {
-			BookEntry entry = ClientBookRegistry.INSTANCE.gson.fromJson(stream, BookEntry.class);
-			if (entry == null) {
-				throw new IllegalArgumentException(file + " does not exist.");
-			}
-
-			entry.setBook(book);
-			if (entry.canAdd()) {
-				BookCategory category = entry.getCategory();
-				if (category != null) {
-					category.addEntry(entry);
-				} else {
-					String msg = String.format("Entry in file %s does not have a valid category.", file);
-					throw new RuntimeException(msg);
-				}
-
-				entry.setId(id);
-				return Optional.of(entry);
-			}
-		} catch (IOException ex) {
-			throw new UncheckedIOException(ex);
-		}
-		return Optional.empty();
-	}
-
-	private void loadTemplate(Identifier key, Identifier res) {
-		String json;
-		try (BufferedReader stream = loadLocalizedJson(res)) {
-			json = stream.lines().collect(Collectors.joining("\n"));
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
-
-		Supplier<BookTemplate> supplier = () -> ClientBookRegistry.INSTANCE.gson.fromJson(json, BookTemplate.class);
-
-		// test supplier
-		BookTemplate template = supplier.get();
-		if (template == null) {
-			throw new IllegalArgumentException(res + " could not be instantiated by the supplier.");
-		}
-
-		templates.put(key, supplier);
-	}
-
-	private BufferedReader loadLocalizedJson(Identifier res) {
-		Identifier localized = new Identifier(res.getNamespace(),
-				res.getPath().replaceAll(DEFAULT_LANG, ClientBookRegistry.INSTANCE.currentLang));
-
-		InputStream input = loadJson(localized, res);
-		if (input == null) {
-			throw new IllegalArgumentException(res + " does not exist.");
-		}
-
-		return new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
-	}
-
-	protected InputStream loadJson(Identifier resloc, Identifier fallback) {
-		String path = "data/" + resloc.getNamespace() + "/" + resloc.getPath();
-		Patchouli.LOGGER.debug("Loading {}", path);
-
-		try {
-			return Files.newInputStream(book.owner.getPath(path));
-		} catch (IOException ex) {
-			if (fallback != null) {
-				Patchouli.LOGGER.warn("Failed to load " + resloc + ". Switching to fallback.");
-				return loadJson(fallback, null);
-			}
-		}
-
-		return null;
 	}
 
 	@Override

--- a/src/main/java/vazkii/patchouli/client/book/BookContentsBuilder.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookContentsBuilder.java
@@ -1,0 +1,188 @@
+package vazkii.patchouli.client.book;
+
+import com.google.common.collect.ImmutableMap;
+
+import net.minecraft.util.Identifier;
+
+import vazkii.patchouli.client.book.template.BookTemplate;
+import vazkii.patchouli.common.book.Book;
+import vazkii.patchouli.common.book.BookRegistry;
+
+import javax.annotation.Nullable;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Holds book content state while it is being assembled from JSON data and extension data.
+ */
+public class BookContentsBuilder {
+	public static final String DEFAULT_LANG = "en_us";
+	private final Map<Identifier, BookCategory> categories = new HashMap<>();
+	private final Map<Identifier, BookEntry> entries = new HashMap<>();
+	private final Map<Identifier, Supplier<BookTemplate>> templates = new HashMap<>();
+
+	private interface LoadFunc<T> {
+		@Nullable
+		T load(Book book, BookContentLoader loader, Identifier id, Identifier file);
+	}
+
+	public BookContentsBuilder() {
+		templates.putAll(BookContents.addonTemplates);
+	}
+
+	@Nullable
+	public BookCategory getCategory(Identifier id) {
+		return categories.get(id);
+	}
+
+	@Nullable
+	public BookEntry getEntry(Identifier id) {
+		return entries.get(id);
+	}
+
+	@Nullable
+	public Supplier<BookTemplate> getTemplate(Identifier id) {
+		return templates.get(id);
+	}
+
+	/**
+	 * Contribute the on-disk contents of the given book to this builder.
+	 * Should first be called with the "real" book, then by all extensions
+	 */
+	public void loadFrom(Book book) {
+		load(book, "categories", BookContentsBuilder::loadCategory, categories);
+		load(book, "entries",
+				(b, l, id, file) -> BookContentsBuilder.loadEntry(b, l, id, file, categories::get),
+				entries);
+		load(book, "templates", BookContentsBuilder::loadTemplate, templates);
+	}
+
+	public BookContents build(Book book) {
+		categories.forEach((id, category) -> {
+			try {
+				category.build(id, this);
+			} catch (Exception e) {
+				throw new RuntimeException("Error while building category " + id, e);
+			}
+		});
+
+		entries.values().forEach(entry -> {
+			try {
+				entry.build(this);
+			} catch (Exception e) {
+				throw new RuntimeException("Error building entry " + entry.getId(), e);
+			}
+		});
+
+		return new BookContents(
+				book,
+				ImmutableMap.copyOf(categories),
+				ImmutableMap.copyOf(entries),
+				ImmutableMap.copyOf(templates)
+		);
+	}
+
+	private <T> void load(Book book, String thing, LoadFunc<T> loader, Map<Identifier, T> builder) {
+		BookContentLoader contentLoader = book.isExternal
+				? BookContentExternalLoader.INSTANCE
+				: BookContentClasspathLoader.INSTANCE;
+		List<Identifier> foundIds = new ArrayList<>();
+		contentLoader.findFiles(book, thing, foundIds);
+
+		for (var id : foundIds) {
+			var filePath = String.format("%s/%s/%s/%s/%s.json",
+					BookRegistry.BOOKS_LOCATION, book.id.getPath(), DEFAULT_LANG, thing, id.getPath());
+			T value = loader.load(book, contentLoader, id, new Identifier(id.getNamespace(), filePath));
+			if (value != null) {
+				builder.put(id, value);
+			}
+		}
+	}
+
+	@Nullable
+	private static BookCategory loadCategory(Book book, BookContentLoader loader, Identifier id, Identifier file) {
+		try (Reader stream = loadLocalizedJson(book, loader, file)) {
+			BookCategory category = ClientBookRegistry.INSTANCE.gson.fromJson(stream, BookCategory.class);
+			if (category == null) {
+				throw new IllegalArgumentException(file + " does not exist.");
+			}
+
+			category.setBook(book);
+			if (category.canAdd()) {
+				return category;
+			}
+			return null;
+		} catch (IOException ex) {
+			throw new UncheckedIOException(ex);
+		}
+	}
+
+	@Nullable
+	private static BookEntry loadEntry(Book book, BookContentLoader loader, Identifier id,
+			Identifier file, Function<Identifier, BookCategory> categories) {
+		try (Reader stream = loadLocalizedJson(book, loader, file)) {
+			BookEntry entry = ClientBookRegistry.INSTANCE.gson.fromJson(stream, BookEntry.class);
+			if (entry == null) {
+				throw new IllegalArgumentException(file + " does not exist.");
+			}
+
+			entry.setBook(book);
+			if (entry.canAdd()) {
+				entry.initCategory(categories);
+
+				BookCategory category = entry.getCategory();
+				if (category != null) {
+					category.addEntry(entry);
+				} else {
+					String msg = String.format("Entry in file %s does not have a valid category.", file);
+					throw new RuntimeException(msg);
+				}
+
+				entry.setId(id);
+				return entry;
+			}
+		} catch (IOException ex) {
+			throw new UncheckedIOException(ex);
+		}
+		return null;
+	}
+
+	private static Supplier<BookTemplate> loadTemplate(Book book, BookContentLoader loader, Identifier key, Identifier res) {
+		String json;
+		try (BufferedReader stream = loadLocalizedJson(book, loader, res)) {
+			json = stream.lines().collect(Collectors.joining("\n"));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+
+		Supplier<BookTemplate> supplier = () -> ClientBookRegistry.INSTANCE.gson.fromJson(json, BookTemplate.class);
+
+		// test supplier
+		BookTemplate template = supplier.get();
+		if (template == null) {
+			throw new IllegalArgumentException(res + " could not be instantiated by the supplier.");
+		}
+
+		return supplier;
+	}
+
+	private static BufferedReader loadLocalizedJson(Book book, BookContentLoader loader, Identifier res) {
+		Identifier localized = new Identifier(res.getNamespace(),
+				res.getPath().replaceAll(DEFAULT_LANG, ClientBookRegistry.INSTANCE.currentLang));
+
+		InputStream input = loader.loadJson(book, localized, res);
+		if (input == null) {
+			throw new IllegalArgumentException(res + " does not exist.");
+		}
+
+		return new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+	}
+}

--- a/src/main/java/vazkii/patchouli/client/book/BookEntry.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookEntry.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class BookEntry extends AbstractReadStateHolder implements Comparable<BookEntry> {
@@ -91,10 +92,10 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 		return icon;
 	}
 
-	public BookCategory getCategory() {
+	public void initCategory(Function<Identifier, BookCategory> categories) {
 		if (lcategory == null) {
 			if (category.contains(":")) { // full category ID
-				lcategory = book.getContents().categories.get(new Identifier(category));
+				lcategory = categories.apply(new Identifier(category));
 			} else {
 				String hint = String.format("`%s:%s`", book.getModNamespace(), category);
 				if (isExtension() && !trueProvider.getModNamespace().equals(book.getModNamespace())) {
@@ -103,7 +104,9 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 				throw new IllegalArgumentException("`category` must be fully qualified (domain:name). Hint: Try " + hint);
 			}
 		}
+	}
 
+	public BookCategory getCategory() {
 		return lcategory;
 	}
 
@@ -202,7 +205,7 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 		this.id = id;
 	}
 
-	public void build() {
+	public void build(BookContentsBuilder builder) {
 		if (built) {
 			return;
 		}
@@ -215,7 +218,7 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 		for (int i = 0; i < pages.length; i++) {
 			if (pages[i].canAdd(book)) {
 				try {
-					pages[i].build(this, i);
+					pages[i].build(this, builder, i);
 					realPages.add(pages[i]);
 				} catch (Exception e) {
 					throw new RuntimeException("Error while loading entry " + id + " page " + i, e);

--- a/src/main/java/vazkii/patchouli/client/book/BookPage.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookPage.java
@@ -34,7 +34,7 @@ public abstract class BookPage {
 
 	protected String type, flag, advancement, anchor;
 
-	public void build(BookEntry entry, int pageNum) {
+	public void build(BookEntry entry, BookContentsBuilder builder, int pageNum) {
 		this.book = entry.getBook();
 		this.entry = entry;
 		this.pageNum = pageNum;

--- a/src/main/java/vazkii/patchouli/client/book/gui/GuiBookLanding.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/GuiBookLanding.java
@@ -187,7 +187,7 @@ public class GuiBookLanding extends GuiBook {
 	public void handleButtonEdit(ButtonWidget button) {
 		if (hasShiftDown()) {
 			long time = System.currentTimeMillis();
-			book.reloadContentsAndExtensions();
+			book.reloadContents();
 			book.reloadLocks(false);
 			displayLexiconGui(new GuiBookLanding(book), false);
 			client.player.sendMessage(new TranslatableText("patchouli.gui.lexicon.reloaded", (System.currentTimeMillis() - time)), false);

--- a/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonIndex.java
+++ b/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonIndex.java
@@ -8,7 +8,7 @@ import vazkii.patchouli.client.book.gui.GuiBook;
 public class GuiButtonIndex extends GuiButtonCategory {
 
 	public GuiButtonIndex(GuiBook parent, int x, int y, ButtonWidget.PressAction onPress) {
-		super(parent, x, y, parent.book.getContents().indexIcon, new TranslatableText("patchouli.gui.lexicon.index"), onPress);
+		super(parent, x, y, parent.book.getIcon(), new TranslatableText("patchouli.gui.lexicon.index"), onPress);
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/client/book/page/PageEntity.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageEntity.java
@@ -13,6 +13,7 @@ import net.minecraft.util.math.Vec3f;
 import net.minecraft.world.World;
 
 import vazkii.patchouli.client.base.ClientTicker;
+import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
@@ -39,8 +40,8 @@ public class PageEntity extends PageWithText {
 	transient float renderScale, offset;
 
 	@Override
-	public void build(BookEntry entry, int pageNum) {
-		super.build(entry, pageNum);
+	public void build(BookEntry entry, BookContentsBuilder builder, int pageNum) {
+		super.build(entry, builder, pageNum);
 
 		creator = EntityUtil.loadEntity(entityId);
 	}

--- a/src/main/java/vazkii/patchouli/client/book/page/PageLink.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageLink.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.text.Text;
 
 import vazkii.patchouli.api.IVariable;
+import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
@@ -18,8 +19,8 @@ public class PageLink extends PageText {
 	transient Text realText;
 
 	@Override
-	public void build(BookEntry entry, int pageNum) {
-		super.build(entry, pageNum);
+	public void build(BookEntry entry, BookContentsBuilder builder, int pageNum) {
+		super.build(entry, builder, pageNum);
 		realText = linkText.as(Text.class);
 	}
 

--- a/src/main/java/vazkii/patchouli/client/book/page/PageMultiblock.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageMultiblock.java
@@ -26,6 +26,7 @@ import vazkii.patchouli.api.IMultiblock;
 import vazkii.patchouli.client.base.ClientTicker;
 import vazkii.patchouli.client.base.PersistentData;
 import vazkii.patchouli.client.base.PersistentData.DataHolder.BookData.Bookmark;
+import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
@@ -59,8 +60,8 @@ public class PageMultiblock extends PageWithText {
 	private transient ButtonWidget visualizeButton;
 
 	@Override
-	public void build(BookEntry entry, int pageNum) {
-		super.build(entry, pageNum);
+	public void build(BookEntry entry, BookContentsBuilder builder, int pageNum) {
+		super.build(entry, builder, pageNum);
 		if (multiblockId != null) {
 			IMultiblock mb = MultiblockRegistry.MULTIBLOCKS.get(multiblockId);
 

--- a/src/main/java/vazkii/patchouli/client/book/page/PageQuest.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageQuest.java
@@ -11,6 +11,7 @@ import net.minecraft.util.Identifier;
 import vazkii.patchouli.client.base.ClientAdvancements;
 import vazkii.patchouli.client.base.PersistentData;
 import vazkii.patchouli.client.base.PersistentData.DataHolder.BookData;
+import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
@@ -30,8 +31,8 @@ public class PageQuest extends PageWithText {
 	}
 
 	@Override
-	public void build(BookEntry entry, int pageNum) {
-		super.build(entry, pageNum);
+	public void build(BookEntry entry, BookContentsBuilder builder, int pageNum) {
+		super.build(entry, builder, pageNum);
 
 		isManual = trigger == null;
 	}

--- a/src/main/java/vazkii/patchouli/client/book/page/PageRelations.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageRelations.java
@@ -5,6 +5,7 @@ import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 
+import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
@@ -25,12 +26,12 @@ public class PageRelations extends PageWithText {
 	transient List<BookEntry> entryObjs;
 
 	@Override
-	public void build(BookEntry entry, int pageNum) {
-		super.build(entry, pageNum);
+	public void build(BookEntry entry, BookContentsBuilder builder, int pageNum) {
+		super.build(entry, builder, pageNum);
 
 		entryObjs = entries.stream()
 				.map(Identifier::new)
-				.map(book.getContents().entries::get)
+				.map(builder::getEntry)
 				.filter(Objects::nonNull)
 				.collect(Collectors.toList());
 	}

--- a/src/main/java/vazkii/patchouli/client/book/page/PageSpotlight.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageSpotlight.java
@@ -10,6 +10,7 @@ import net.minecraft.recipe.Ingredient;
 import net.minecraft.text.Text;
 
 import vazkii.patchouli.api.IVariable;
+import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.page.abstr.PageWithText;
@@ -23,8 +24,8 @@ public class PageSpotlight extends PageWithText {
 	transient Ingredient ingredient;
 
 	@Override
-	public void build(BookEntry entry, int pageNum) {
-		super.build(entry, pageNum);
+	public void build(BookEntry entry, BookContentsBuilder builder, int pageNum) {
+		super.build(entry, builder, pageNum);
 		ingredient = item.as(Ingredient.class);
 
 		if (linkRecipe) {

--- a/src/main/java/vazkii/patchouli/client/book/page/PageTemplate.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/PageTemplate.java
@@ -2,25 +2,30 @@ package vazkii.patchouli.client.book.page;
 
 import net.minecraft.client.util.math.MatrixStack;
 
+import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.BookPage;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
 import vazkii.patchouli.client.book.template.BookTemplate;
 import vazkii.patchouli.client.book.template.JsonVariableWrapper;
-import vazkii.patchouli.common.book.Book;
 
 public class PageTemplate extends BookPage {
 
-	transient BookTemplate template = null;
-	transient boolean resolved = false;
+	private transient BookTemplate template = null;
+	private transient boolean resolved = false;
 
 	@Override
-	public void build(BookEntry entry, int pageNum) {
-		super.build(entry, pageNum);
+	public void build(BookEntry entry, BookContentsBuilder builder, int pageNum) {
+		super.build(entry, builder, pageNum);
+
+		if (!resolved) {
+			template = BookTemplate.createTemplate(book, builder, type, null);
+			resolved = true;
+		}
 
 		JsonVariableWrapper wrapper = new JsonVariableWrapper(sourceObject);
 
-		template.compile(wrapper);
+		template.compile(builder, wrapper);
 		template.build(this, entry, pageNum);
 	}
 
@@ -39,15 +44,5 @@ public class PageTemplate extends BookPage {
 	@Override
 	public boolean mouseClicked(double mouseX, double mouseY, int mouseButton) {
 		return template.mouseClicked(this, mouseX, mouseY, mouseButton);
-	}
-
-	@Override
-	public boolean canAdd(Book book) {
-		if (!resolved) {
-			template = BookTemplate.createTemplate(book, type, null);
-			resolved = true;
-		}
-
-		return template != null && super.canAdd(book);
 	}
 }

--- a/src/main/java/vazkii/patchouli/client/book/page/abstr/PageDoubleRecipe.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/abstr/PageDoubleRecipe.java
@@ -8,6 +8,7 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
+import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
 
@@ -21,8 +22,8 @@ public abstract class PageDoubleRecipe<T> extends PageWithText {
 	protected transient Text title1, title2;
 
 	@Override
-	public void build(BookEntry entry, int pageNum) {
-		super.build(entry, pageNum);
+	public void build(BookEntry entry, BookContentsBuilder builder, int pageNum) {
+		super.build(entry, builder, pageNum);
 
 		recipe1 = loadRecipe(entry, recipeId);
 		recipe2 = loadRecipe(entry, recipe2Id);

--- a/src/main/java/vazkii/patchouli/client/book/page/abstr/PageDoubleRecipeRegistry.java
+++ b/src/main/java/vazkii/patchouli/client/book/page/abstr/PageDoubleRecipeRegistry.java
@@ -5,8 +5,10 @@ import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeManager;
 import net.minecraft.recipe.RecipeType;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 
 import vazkii.patchouli.client.book.BookEntry;
+import vazkii.patchouli.common.base.Patchouli;
 import vazkii.patchouli.mixin.AccessorRecipeManager;
 
 import javax.annotation.Nullable;
@@ -43,6 +45,7 @@ public abstract class PageDoubleRecipeRegistry<T extends Recipe<?>> extends Page
 			return tempRecipe;
 		}
 
+		Patchouli.LOGGER.warn("Recipe {} (of type {}) not found", res, Registry.RECIPE_TYPE.getId(recipeType));
 		return null;
 	}
 

--- a/src/main/java/vazkii/patchouli/client/book/template/BookTemplate.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/BookTemplate.java
@@ -7,6 +7,7 @@ import net.minecraft.util.Identifier;
 
 import vazkii.patchouli.api.IComponentProcessor;
 import vazkii.patchouli.api.IVariableProvider;
+import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.BookPage;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
@@ -55,7 +56,7 @@ public class BookTemplate {
 	transient boolean compiled = false;
 	transient boolean attemptedCreatingProcessor = false;
 
-	public static BookTemplate createTemplate(Book book, String type, @Nullable TemplateInclusion inclusion) {
+	public static BookTemplate createTemplate(Book book, BookContentsBuilder builder, String type, @Nullable TemplateInclusion inclusion) {
 		Identifier key;
 		if (type.contains(":")) {
 			key = new Identifier(type);
@@ -63,7 +64,7 @@ public class BookTemplate {
 			key = new Identifier(book.getModNamespace(), type);
 		}
 
-		Supplier<BookTemplate> supplier = book.getContents().templates.get(key);
+		Supplier<BookTemplate> supplier = builder.getTemplate(key);
 		if (supplier == null) {
 			throw new IllegalArgumentException("Template " + key + " does not exist");
 		}
@@ -75,7 +76,7 @@ public class BookTemplate {
 		return template;
 	}
 
-	public void compile(IVariableProvider variables) {
+	public void compile(BookContentsBuilder builder, IVariableProvider variables) {
 		if (compiled) {
 			return;
 		}
@@ -104,8 +105,8 @@ public class BookTemplate {
 			include.upperMerge(encapsulation);
 			include.process(processor);
 
-			BookTemplate template = createTemplate(book, include.template, include);
-			template.compile(variables);
+			BookTemplate template = createTemplate(book, builder, include.template, include);
+			template.compile(builder, variables);
 			components.addAll(template.components);
 		}
 

--- a/src/main/java/vazkii/patchouli/common/book/BookRegistry.java
+++ b/src/main/java/vazkii/patchouli/common/book/BookRegistry.java
@@ -82,6 +82,20 @@ public class BookRegistry {
 		});
 
 		BookFolderLoader.findBooks();
+
+		for (var book : books.values()) {
+			if (book.isExtension) {
+				book.extensionTarget = books.get(book.extend);
+
+				if (book.extensionTarget == null) {
+					throw new IllegalArgumentException("Extension Book " + book.id + " has no valid target");
+				} else if (!book.extensionTarget.allowExtensions) {
+					throw new IllegalArgumentException("Book " + book.extensionTarget.id + " doesn't allow extensions, so " + book.id + " can't modify it");
+				}
+
+				book.extensionTarget.extensions.add(book);
+			}
+		}
 	}
 
 	public void loadBook(ModContainer mod, Identifier res, InputStream stream,
@@ -96,7 +110,6 @@ public class BookRegistry {
 	public void reloadContents() {
 		PatchouliConfig.reloadBuiltinFlags();
 		books.values().forEach(Book::reloadContents);
-		books.values().forEach(Book::reloadExtensionContents);
 		ClientBookRegistry.INSTANCE.reloadLocks(false);
 		loaded = true;
 	}


### PR DESCRIPTION
* Get rid of ExternalBookContents, make loading from folder vs from classpath distinction transparent to the loader (see BookContentsLoader)
* Makes BookContents mostly immutable and disposable. To reload contents, just discard the entire `contents` object and make a new one.


Letting this bake in public in case anyone has any opinions, otherwise I'm going to merge it and keep going in a couple days.