### PR TITLE
 Remove Patchouli's bespoke string formatting 

### DIFF
--- a/src/main/java/vazkii/patchouli/client/book/BookCategory.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookCategory.java
@@ -1,6 +1,7 @@
 package vazkii.patchouli.client.book;
 
 import com.google.common.collect.Streams;
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
 
 import net.minecraft.text.LiteralText;
@@ -17,7 +18,7 @@ import java.util.List;
 public class BookCategory extends AbstractReadStateHolder implements Comparable<BookCategory> {
 
 	private String name, description, parent, flag;
-	@SerializedName("icon") private String iconRaw;
+	@SerializedName("icon") private JsonElement iconRaw;
 	private int sortnum;
 	private boolean secret = false;
 

--- a/src/main/java/vazkii/patchouli/client/book/BookEntry.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookEntry.java
@@ -1,7 +1,6 @@
 package vazkii.patchouli.client.book;
 
 import com.google.common.collect.ImmutableList;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
@@ -228,13 +227,8 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 
 		if (extraRecipeMappings != null) {
 			for (var obj : extraRecipeMappings) {
-				ItemStack[] stacks;
-				if (obj.has("item")) {
-					stacks =  new ItemStack[] { ItemStackUtil.loadStackFromJson(obj.get("item")) };
-				} else {
-					Ingredient ingr = Ingredient.fromJson(obj.get("items"));
-					stacks = ingr.getMatchingStacksClient();
-				}
+				Ingredient ingr = Ingredient.fromJson(obj.get("match"));
+				ItemStack[] stacks = ingr.getMatchingStacksClient();
 
 				int pageNumber = obj.getAsJsonPrimitive("page").getAsInt();
 				if (stacks.length > 0 && pageNumber < pages.length) {

--- a/src/main/java/vazkii/patchouli/client/book/BookIcon.java
+++ b/src/main/java/vazkii/patchouli/client/book/BookIcon.java
@@ -1,5 +1,6 @@
 package vazkii.patchouli.client.book;
 
+import com.google.gson.JsonElement;
 import com.mojang.blaze3d.systems.RenderSystem;
 
 import net.minecraft.client.MinecraftClient;
@@ -19,13 +20,12 @@ public class BookIcon {
 	private final ItemStack stack;
 	private final Identifier res;
 
-	public static BookIcon from(String str) {
-		if (str.endsWith(".png")) {
-			return new BookIcon(new Identifier(str));
+	public static BookIcon from(JsonElement json) {
+		if (json.isJsonPrimitive() && json.getAsString().endsWith(".png")) {
+			return new BookIcon(new Identifier(json.getAsString()));
 		} else {
 			try {
-				ItemStack stack = ItemStackUtil.loadStackFromString(str);
-				return new BookIcon(stack);
+				return new BookIcon(ItemStackUtil.loadStackFromJson(json));
 			} catch (Exception e) {
 				Patchouli.LOGGER.warn("Invalid icon item stack: {}", e.getMessage());
 				return EMPTY;

--- a/src/main/java/vazkii/patchouli/client/book/template/variable/GenericArrayVariableSerializer.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/variable/GenericArrayVariableSerializer.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class GenericArrayVariableSerializer<T> implements IVariableSerializer<T[]> {
 	protected final T[] empty;
-	private final IVariableSerializer<T> inner;
+	protected final IVariableSerializer<T> inner;
 
 	@SuppressWarnings("unchecked")
 	public GenericArrayVariableSerializer(IVariableSerializer<T> inner, Class<T> type) {

--- a/src/main/java/vazkii/patchouli/client/book/template/variable/IngredientVariableSerializer.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/variable/IngredientVariableSerializer.java
@@ -8,9 +8,14 @@ import vazkii.patchouli.api.IVariableSerializer;
 import vazkii.patchouli.common.util.ItemStackUtil;
 
 public class IngredientVariableSerializer implements IVariableSerializer<Ingredient> {
+	public static final IngredientVariableSerializer INSTANCE = new IngredientVariableSerializer();
+
 	@Override
 	public Ingredient fromJson(JsonElement json) {
-		return (json.isJsonPrimitive()) ? ItemStackUtil.loadIngredientFromString(json.getAsString()) : Ingredient.fromJson(json);
+		if (json.isJsonPrimitive()) {
+			return Ingredient.ofStacks(ItemStackUtil.loadStackFromJson(json));
+		}
+		return Ingredient.fromJson(json);
 	}
 
 	@Override

--- a/src/main/java/vazkii/patchouli/client/book/template/variable/ItemStackArrayVariableSerializer.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/variable/ItemStackArrayVariableSerializer.java
@@ -5,10 +5,7 @@ import com.google.gson.JsonElement;
 
 import net.minecraft.item.ItemStack;
 
-import vazkii.patchouli.common.util.ItemStackUtil;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class ItemStackArrayVariableSerializer extends GenericArrayVariableSerializer<ItemStack> {

--- a/src/main/java/vazkii/patchouli/client/book/template/variable/ItemStackArrayVariableSerializer.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/variable/ItemStackArrayVariableSerializer.java
@@ -22,7 +22,7 @@ public class ItemStackArrayVariableSerializer extends GenericArrayVariableSerial
 			JsonArray array = json.getAsJsonArray();
 			List<ItemStack> stacks = new ArrayList<>();
 			for (JsonElement e : array) {
-				stacks.addAll(Arrays.asList(fromNonArray(e)));
+				stacks.add(inner.fromJson(e));
 			}
 			return stacks.toArray(empty);
 		}
@@ -33,13 +33,7 @@ public class ItemStackArrayVariableSerializer extends GenericArrayVariableSerial
 		if (json.isJsonNull()) {
 			return empty;
 		}
-		if (json.isJsonPrimitive()) {
-			return ItemStackUtil.loadStackListFromString(json.getAsString()).toArray(empty);
-		}
-		if (json.isJsonObject()) {
-			return new ItemStack[] { ItemStackUtil.loadStackFromJson(json.getAsJsonObject()) };
-		}
-		throw new IllegalArgumentException("Can't make an ItemStack from an array!");
+		return new ItemStack[] { inner.fromJson(json) };
 	}
 
 }

--- a/src/main/java/vazkii/patchouli/client/book/template/variable/ItemStackVariableSerializer.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/variable/ItemStackVariableSerializer.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
 import vazkii.patchouli.api.IVariableSerializer;

--- a/src/main/java/vazkii/patchouli/client/book/template/variable/ItemStackVariableSerializer.java
+++ b/src/main/java/vazkii/patchouli/client/book/template/variable/ItemStackVariableSerializer.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
 import vazkii.patchouli.api.IVariableSerializer;
@@ -12,16 +13,7 @@ import vazkii.patchouli.common.util.ItemStackUtil;
 public class ItemStackVariableSerializer implements IVariableSerializer<ItemStack> {
 	@Override
 	public ItemStack fromJson(JsonElement json) {
-		if (json.isJsonNull()) {
-			return ItemStack.EMPTY;
-		}
-		if (json.isJsonPrimitive()) {
-			return ItemStackUtil.loadStackFromString(json.getAsString());
-		}
-		if (json.isJsonObject()) {
-			return ItemStackUtil.loadStackFromJson(json.getAsJsonObject());
-		}
-		throw new IllegalArgumentException("Can't make an ItemStack from an array!");
+		return ItemStackUtil.loadStackFromJson(json);
 	}
 
 	@Override

--- a/src/main/java/vazkii/patchouli/common/book/Book.java
+++ b/src/main/java/vazkii/patchouli/common/book/Book.java
@@ -1,5 +1,6 @@
 package vazkii.patchouli.common.book;
 
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
 
 import net.fabricmc.api.EnvType;
@@ -85,7 +86,7 @@ public class Book {
 
 	@SerializedName("show_progress") public boolean showProgress = true;
 
-	@SerializedName("index_icon") public String indexIconRaw = "";
+	@SerializedName("index_icon") public JsonElement indexIconRaw;
 
 	public String version = "0";
 	public String subtitle = "";
@@ -96,7 +97,7 @@ public class Book {
 
 	@SerializedName("dont_generate_book") public boolean noBook = false;
 
-	@SerializedName("custom_book_item") public String customBookItem = "";
+	@SerializedName("custom_book_item") public JsonElement customBookItem;
 
 	@SerializedName("show_toasts") public boolean showToasts = true;
 
@@ -141,7 +142,7 @@ public class Book {
 	public ItemStack getBookItem() {
 		if (bookItem == null) {
 			if (noBook) {
-				bookItem = ItemStackUtil.loadStackFromString(customBookItem);
+				bookItem = ItemStackUtil.loadStackFromJson(customBookItem);
 			} else {
 				bookItem = ItemModBook.forBook(this);
 			}
@@ -236,7 +237,7 @@ public class Book {
 
 	@Environment(EnvType.CLIENT)
 	public BookIcon getIcon() {
-		if (indexIconRaw == null || indexIconRaw.isEmpty()) {
+		if (indexIconRaw == null) {
 			return new BookIcon(getBookItem());
 		} else {
 			return BookIcon.from(indexIconRaw);

--- a/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
+++ b/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
@@ -3,19 +3,14 @@ package vazkii.patchouli.common.util;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.JsonOps;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtOps;
-import net.minecraft.nbt.StringNbtReader;
 import net.minecraft.recipe.ShapedRecipe;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.JsonHelper;
 import net.minecraft.util.registry.Registry;
 
 import vazkii.patchouli.common.book.Book;

--- a/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
+++ b/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
@@ -13,6 +13,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.StringNbtReader;
+import net.minecraft.recipe.ShapedRecipe;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.registry.Registry;
@@ -104,34 +105,7 @@ public final class ItemStackUtil {
 			Item item = Registry.ITEM.getOrEmpty(id).orElseThrow(() -> new IllegalArgumentException("Unknown item '" + id + "'"));
 			return new ItemStack(item);
 		} else {
-			return loadStackFromJsonObject(json.getAsJsonObject());
+			return ShapedRecipe.outputFromJson(json.getAsJsonObject());
 		}
-	}
-
-	private static ItemStack loadStackFromJsonObject(JsonObject json) {
-		// Adapted from net.minecraftforge.common.crafting.CraftingHelper::getItemStack
-		String itemName = json.get("item").getAsString();
-
-		Item item = Registry.ITEM.getOrEmpty(new Identifier(itemName)).orElseThrow(() -> new IllegalArgumentException("Unknown item '" + itemName + "'")
-		);
-
-		ItemStack stack = new ItemStack(item, JsonHelper.getInt(json, "count", 1));
-
-		if (json.has("nbt")) {
-			try {
-				JsonElement element = json.get("nbt");
-				NbtCompound nbt;
-				if (element.isJsonObject()) {
-					nbt = StringNbtReader.parse(GSON.toJson(element));
-				} else {
-					nbt = StringNbtReader.parse(element.getAsString());
-				}
-				stack.setTag(nbt);
-			} catch (CommandSyntaxException e) {
-				throw new IllegalArgumentException("Invalid NBT Entry: " + e.toString(), e);
-			}
-		}
-
-		return stack;
 	}
 }

--- a/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
+++ b/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
@@ -13,9 +13,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.StringNbtReader;
-import net.minecraft.recipe.Ingredient;
-import net.minecraft.tag.ItemTags;
-import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.registry.Registry;
@@ -23,14 +20,10 @@ import net.minecraft.util.registry.Registry;
 import vazkii.patchouli.common.book.Book;
 import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.item.ItemModBook;
-import vazkii.patchouli.mixin.AccessorIngredient;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import java.util.StringJoiner;
 
 public final class ItemStackUtil {
 	private static final Gson GSON = new GsonBuilder().create();

--- a/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
+++ b/src/main/java/vazkii/patchouli/common/util/ItemStackUtil.java
@@ -56,87 +56,6 @@ public final class ItemStackUtil {
 		return builder.toString();
 	}
 
-	public static ItemStack loadStackFromString(String res) {
-		String nbt = "";
-		int nbtStart = res.indexOf("{");
-		if (nbtStart > 0) {
-			nbt = res.substring(nbtStart).replaceAll("([^\\\\])'", "$1\"").replaceAll("\\\\'", "'");
-			res = res.substring(0, nbtStart);
-		}
-
-		String[] upper = res.split("#");
-		String count = "1";
-		if (upper.length > 1) {
-			res = upper[0];
-			count = upper[1];
-		}
-
-		String[] tokens = res.split(":");
-		if (tokens.length < 2) {
-			return ItemStack.EMPTY;
-		}
-
-		int countn = Integer.parseInt(count);
-		Identifier key = new Identifier(tokens[0], tokens[1]);
-		var maybeItem = Registry.ITEM.getOrEmpty(key);
-		if (!maybeItem.isPresent()) {
-			throw new RuntimeException("Unknown item ID: " + key);
-		}
-		Item item = maybeItem.get();
-		ItemStack stack = new ItemStack(item, countn);
-
-		if (!nbt.isEmpty()) {
-			try {
-				stack.setTag(StringNbtReader.parse(nbt));
-			} catch (CommandSyntaxException e) {
-				throw new RuntimeException("Failed to parse ItemStack JSON", e);
-			}
-		}
-
-		return stack;
-	}
-
-	public static String serializeIngredient(Ingredient ingredient) {
-		((AccessorIngredient) (Object) ingredient).callCacheMatchingStacks();
-		ItemStack[] stacks = ((AccessorIngredient) (Object) ingredient).getMatchingStacks();
-		String[] stacksSerialized = new String[stacks.length];
-		for (int i = 0; i < stacks.length; i++) {
-			stacksSerialized[i] = serializeStack(stacks[i]);
-		}
-
-		return String.join(",", stacksSerialized);
-	}
-
-	public static Ingredient loadIngredientFromString(String ingredientString) {
-		return Ingredient.ofStacks(loadStackListFromString(ingredientString).toArray(new ItemStack[0]));
-	}
-
-	public static String serializeStackList(List<ItemStack> stacks) {
-		StringJoiner joiner = new StringJoiner(",");
-		for (ItemStack stack : stacks) {
-			joiner.add(serializeStack(stack));
-		}
-		return joiner.toString();
-	}
-
-	public static List<ItemStack> loadStackListFromString(String ingredientString) {
-		String[] stacksSerialized = splitStacksFromSerializedIngredient(ingredientString);
-		List<ItemStack> stacks = new ArrayList<>();
-		for (String s : stacksSerialized) {
-			if (s.startsWith("tag:")) {
-				Tag<Item> tag = ItemTags.getTagGroup().getTag(new Identifier(s.substring(4)));
-				if (tag != null) {
-					for (Item item : tag.values()) {
-						stacks.add(new ItemStack(item));
-					}
-				}
-			} else {
-				stacks.add(loadStackFromString(s));
-			}
-		}
-		return stacks;
-	}
-
 	public static StackWrapper wrapStack(ItemStack stack) {
 		return stack.isEmpty() ? StackWrapper.EMPTY_WRAPPER : new StackWrapper(stack);
 	}
@@ -184,45 +103,19 @@ public final class ItemStackUtil {
 
 	}
 
-	private static String[] splitStacksFromSerializedIngredient(String ingredientSerialized) {
-		final List<String> result = new ArrayList<>();
-
-		int lastIndex = 0;
-		int braces = 0;
-		Character insideString = null;
-		for (int i = 0; i < ingredientSerialized.length(); i++) {
-			switch (ingredientSerialized.charAt(i)) {
-			case '{':
-				if (insideString == null) {
-					braces++;
-				}
-				break;
-			case '}':
-				if (insideString == null) {
-					braces--;
-				}
-				break;
-			case '\'':
-				insideString = insideString == null ? '\'' : null;
-				break;
-			case '"':
-				insideString = insideString == null ? '"' : null;
-				break;
-			case ',':
-				if (braces <= 0) {
-					result.add(ingredientSerialized.substring(lastIndex, i));
-					lastIndex = i + 1;
-					break;
-				}
-			}
+	public static ItemStack loadStackFromJson(JsonElement json) {
+		if (json.isJsonNull()) {
+			return ItemStack.EMPTY;
+		} else if (json.isJsonPrimitive()) {
+			Identifier id = new Identifier(json.getAsString());
+			Item item = Registry.ITEM.getOrEmpty(id).orElseThrow(() -> new IllegalArgumentException("Unknown item '" + id + "'"));
+			return new ItemStack(item);
+		} else {
+			return loadStackFromJsonObject(json.getAsJsonObject());
 		}
-
-		result.add(ingredientSerialized.substring(lastIndex));
-
-		return result.toArray(new String[0]);
 	}
 
-	public static ItemStack loadStackFromJson(JsonObject json) {
+	private static ItemStack loadStackFromJsonObject(JsonObject json) {
 		// Adapted from net.minecraftforge.common.crafting.CraftingHelper::getItemStack
 		String itemName = json.get("item").getAsString();
 

--- a/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/page_types/spotlight.json
+++ b/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/page_types/spotlight.json
@@ -10,24 +10,42 @@
     },
     {
       "type": "patchouli:spotlight",
-      "item": "minecraft:dead_bush,minecraft:spruce_sapling",
+      "item": [
+        {
+          "item": "minecraft:dead_bush"
+        },
+        {
+          "item": "minecraft:spruce_sapling"
+        }
+      ],
       "title": "Custom title",
       "text": "Custom text $(l)with formatting$()."
     },
     {
       "type": "patchouli:spotlight",
-      "item": "tag:minecraft:piglin_loved",
+      "item": {
+        "tag": "minecraft:piglin_loved"
+      },
       "title": "Tag Spotlight",
       "text": "Piglins love these!",
       "link_recipe": true
     },
     {
       "type": "patchouli:spotlight",
-      "item": "tag:minecraft:piglin_repellents"
+      "item": {
+        "tag": "minecraft:piglin_repellents"
+      }
     },
     {
       "type": "patchouli:spotlight",
-      "item": "tag:minecraft:wool,minecraft:bone",
+      "item": [
+        {
+          "tag": "minecraft:wool"
+        },
+        {
+          "item": "minecraft:bone"
+        }
+      ],
       "title": "Wool",
       "text": "But also a bone?"
     }

--- a/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/recipe_mapping/extra.json
+++ b/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/recipe_mapping/extra.json
@@ -17,11 +17,13 @@
   ],
   "extra_recipe_mappings": [
     {
-      "item": "minecraft:grass_block",
+      "match": {
+        "item": "minecraft:grass_block"
+      },
       "page": 0
     },
     {
-      "items": {
+      "match": {
         "tag": "minecraft:logs"
       },
       "page": 2

--- a/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/recipe_mapping/extra.json
+++ b/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/recipe_mapping/extra.json
@@ -15,8 +15,16 @@
       "text": "Logs should be mapped here"
     }
   ],
-  "extra_recipe_mappings": {
-    "minecraft:grass_block": 0,
-    "tag:minecraft:logs": 2
-  }
+  "extra_recipe_mappings": [
+    {
+      "item": "minecraft:grass_block",
+      "page": 0
+    },
+    {
+      "items": {
+        "tag": "minecraft:logs"
+      },
+      "page": 2
+    }
+  ]
 }

--- a/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/templates/builtin_components.json
+++ b/src/main/resources/data/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/templates/builtin_components.json
@@ -7,7 +7,9 @@
       "type": "patchouli:builtin_components_1",
       "headertext": "Header component",
       "texttext": "Text component section",
-      "item": "minecraft:poisonous_potato",
+      "item": {
+        "item": "minecraft:poisonous_potato"
+      },
       "image": "minecraft:textures/item/end_crystal.png"
     },
     {

--- a/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/intro/smelttest.json
+++ b/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/intro/smelttest.json
@@ -51,11 +51,36 @@
             "text": "This book is dedicated all the people around me who strive to have a positive impact on others' lives, especially $(bold)Knoll$(), $(bold)Rosalino$(), and $(bold)Kaizer$(). It's been a long journey, and you made me able to get through it.$(br2)Last but not least, you, the reader, player of mods. This book would not exist without your devotion, and you are to be thanked for that as well. I hope you enjoy it."
         }
     ],
-    "extra_recipe_mappings": {
-        "minecraft:dirt": 1,
-        "minecraft:stone": 3,
-        "minecraft:diamond_ore": 5,
-        "tag:minecraft:logs": 1,
-        "minecraft:diamond": 888
-    }
+    "extra_recipe_mappings": [
+        {
+            "items": {
+                "item": "minecraft:dirt"
+            },
+            "page": 1
+        },
+        {
+            "items": {
+                "item": "minecraft:stone"
+            },
+            "page": 3
+        },
+        {
+            "items": {
+                "item": "minecraft:diamond_ore"
+            },
+            "page": 5
+        },
+        {
+            "items": {
+                "tag": "minecraft:logs"
+            },
+            "page": 1
+        },
+        {
+            "items": {
+                "item": "minecraft:diamond"
+            },
+            "page": 888
+        }
+    ]
 }

--- a/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/intro/smelttest.json
+++ b/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/intro/smelttest.json
@@ -53,31 +53,31 @@
     ],
     "extra_recipe_mappings": [
         {
-            "items": {
+            "match": {
                 "item": "minecraft:dirt"
             },
             "page": 1
         },
         {
-            "items": {
+            "match": {
                 "item": "minecraft:stone"
             },
             "page": 3
         },
         {
-            "items": {
+            "match": {
                 "item": "minecraft:diamond_ore"
             },
             "page": 5
         },
         {
-            "items": {
+            "match": {
                 "tag": "minecraft:logs"
             },
             "page": 1
         },
         {
-            "items": {
+            "match": {
                 "item": "minecraft:diamond"
             },
             "page": 888

--- a/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/test/netherportal.json
+++ b/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/test/netherportal.json
@@ -29,7 +29,10 @@
       "type": "patchouli:spotlight",
       "title": "Make it Lit!",
       "text": "Just set a top face of one of two bottom obsidian blocks on fire and BOOM! you got yourself a ticket to hell!",
-      "item": "minecraft:flint_and_steel#10"
+      "item": {
+        "item": "minecraft:flint_and_steel",
+        "count": 10
+      }
     }, {
       "type": "patchouli:multiblock",
       "name": "The Result!",


### PR DESCRIPTION
All item stacks in the JSON are specified using vanilla's stack and ingredient
formats, with string shorthand in a few spots.

Needs more testing especially around variable substitution.

@Alwinfy review appreciated